### PR TITLE
Delete endpoint of executive token should mention id in query parameter

### DIFF
--- a/app/api/bearer.py
+++ b/app/api/bearer.py
@@ -9,6 +9,12 @@ role-based access control in API endpoints.
 from fastapi.security import HTTPBearer
 
 # Define HTTP Bearer authentication schemes for different user roles
-bearer_executive = HTTPBearer(scheme_name="Executive HTTP Bearer")
-bearer_vendor = HTTPBearer(scheme_name="Vendor HTTP Bearer")
-bearer_operator = HTTPBearer(scheme_name="Operator HTTP Bearer")
+bearer_executive = HTTPBearer(
+    scheme_name="ExecutiveBearer", description="HTTP Bearer token for Executive APIs"
+)
+bearer_vendor = HTTPBearer(
+    scheme_name="VendorBearer", description="HTTP Bearer token for Vendor APIs"
+)
+bearer_operator = HTTPBearer(
+    scheme_name="OperatorBearer", description="HTTP Bearer token for Operator APIs"
+)

--- a/app/api/bearer.py
+++ b/app/api/bearer.py
@@ -10,11 +10,11 @@ from fastapi.security import HTTPBearer
 
 # Define HTTP Bearer authentication schemes for different user roles
 bearer_executive = HTTPBearer(
-    scheme_name="ExecutiveBearer", description="HTTP Bearer token for Executive APIs"
+    scheme_name="ExecutiveBearer", description="HTTP Bearer for Executive APIs"
 )
 bearer_vendor = HTTPBearer(
-    scheme_name="VendorBearer", description="HTTP Bearer token for Vendor APIs"
+    scheme_name="VendorBearer", description="HTTP Bearer for Vendor APIs"
 )
 bearer_operator = HTTPBearer(
-    scheme_name="OperatorBearer", description="HTTP Bearer token for Operator APIs"
+    scheme_name="OperatorBearer", description="HTTP Bearer for Operator APIs"
 )

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -306,9 +306,9 @@ async def delete_token(
     """
     **Deletes an access token associated with an executive account.**
 
-    - Verifies that the provided access token exists and is valid.
-    - The logged-in executive can delete their own tokens without additional permissions.
-    - The specified token will be revoked after validating user permissions 'executive.token.delete'.
+    - Verifies that the bearer access token is valid.
+    - Executives can delete their own tokens without additional permissions.
+    - To delete another executive's token, the 'executive.token.delete' permission is required.
     - If the token ID is invalid or already revoked, the operation is silently ignored.
     """
 

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -92,12 +92,6 @@ class UpdateForm(BaseModel):
     )
 
 
-class DeleteForm(BaseModel):
-    """Form data for deleting an executive token."""
-
-    id: int
-
-
 class LogoutForm(BaseModel):
     """Form data for logging out with an executive token."""
 
@@ -299,7 +293,7 @@ async def revoke_token(
     ),
 )
 async def delete_token(
-    form_param: DeleteForm = Depends(),
+    id: int,
     bearer=Depends(bearer_executive),
     request_info=Depends(get_request_info),
 ):
@@ -318,8 +312,8 @@ async def delete_token(
 
         token_to_delete = (
             session.query(ExecutiveToken)
-            .filter(ExecutiveToken.id == form_param.id)
-            .filter(ExecutiveToken.is_revoked == False)
+            .filter(ExecutiveToken.id == id)
+            .filter(ExecutiveToken.is_revoked.is_(False))
             .first()
         )
         if token_to_delete is None:

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -254,9 +254,9 @@ async def revoke_token(
     """
     **Revokes an access token or refresh token associated with the executive.**
 
-    - Verifies that the provided access token exists and is valid.
-    - Logs out the executive by revoking the associated access token.
-    - If the token is invalid or already revoked, the operation is silently ignored.
+    - Authenticates the executive using the bearer token.
+    - Revokes the token (access or refresh) specified in the request body.
+    - If the token is invalid, doesn't belong to the executive, or is already revoked, the operation is silently ignored.
     """
 
     try:

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -259,7 +259,7 @@ async def revoke_token(
 
         token_to_revoke = (
             session.query(ExecutiveToken)
-            .filter(ExecutiveToken.id == token.id)
+            .filter(ExecutiveToken.executive_id  == token.executive_id )
             .filter(
                 (ExecutiveToken.access_token == form_param.token)
                 | (ExecutiveToken.refresh_token == form_param.token)

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -270,7 +270,7 @@ async def revoke_token(
                 (ExecutiveToken.access_token == form_param.token)
                 | (ExecutiveToken.refresh_token == form_param.token)
             )
-            .filter(ExecutiveToken.is_revoked == False)
+            .filter(ExecutiveToken.is_revoked.is_(False))
             .first()
         )
         if token_to_revoke:

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -95,7 +95,13 @@ class UpdateForm(BaseModel):
 class DeleteForm(BaseModel):
     """Form data for deleting an executive token."""
 
-    id: int | None = Field(Form(default=None))
+    id: int
+
+
+class LogoutForm(BaseModel):
+    """Form data for logging out an executive token."""
+
+    token: str = Field(Form())
 
 
 ## Query Parameters
@@ -237,7 +243,51 @@ async def refresh_token(
 @route_executive.post(
     URL_EXECUTIVE_TOKEN + "/revoke",
     tags=["Token"],
-    status_code=status.HTTP_201_CREATED,
+    status_code=status.HTTP_200_OK,
+    responses=fuse_exception_responses([exceptions.InvalidToken()]),
+)
+async def revoke_token(
+    form_param: LogoutForm = Depends(),
+    bearer=Depends(bearer_executive),
+    request_info=Depends(get_request_info),
+):
+    """
+    **Revokes an access token associated with the executive.**
+
+    - Verifies that the provided access token exists and is valid.
+    - Logs out the executive by revoking the current access token.
+    - If the token is invalid or already revoked, the operation is silently ignored.
+    """
+
+    try:
+        session = SessionLocal()
+        token = verify_token(session, ExecutiveToken, bearer.credentials)
+
+        token_to_revoke = (
+            session.query(ExecutiveToken)
+            .filter(ExecutiveToken.id == token.id)
+            .filter(ExecutiveToken.access_token == form_param.token)
+            .filter(ExecutiveToken.is_revoked == False)
+            .first()
+        )
+        if token_to_revoke:
+            token_to_revoke.is_revoked = True
+            session.commit()
+            session.refresh(token_to_revoke)
+            _, token_log_data = token_to_json(token_to_revoke)
+            log_event(token_to_revoke, request_info, token_log_data)
+
+        return Response(status_code=status.HTTP_200_OK)
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_executive.delete(
+    URL_EXECUTIVE_TOKEN + "/{id}",
+    tags=["Token"],
+    status_code=status.HTTP_204_NO_CONTENT,
     responses=fuse_exception_responses(
         [
             exceptions.InvalidToken(),
@@ -245,49 +295,43 @@ async def refresh_token(
         ]
     ),
 )
-async def revoke_token(
+async def delete_token(
     form_param: DeleteForm = Depends(),
     bearer=Depends(bearer_executive),
     request_info=Depends(get_request_info),
 ):
     """
-    **Revokes an access token associated with an executive account.**
+    **Deletes an access token associated with an executive account.**
 
     - Verifies that the provided access token exists and is valid.
-    - If no `id` is provided, the currently used token will be revoked.
-    - If an `id` is provided, the specified token will be revoked after validating user permissions 'executive.token.delete'.
-    - If the token id is invalid or already revoked, the operation is silently ignored.
+    - The logged-in executive can delete their own tokens without additional permissions.
+    - The specified token will be revoked after validating user permissions 'executive.token.delete'.
+    - If the token ID is invalid or already revoked, the operation is silently ignored.
     """
 
     try:
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, bearer.credentials)
 
-        if form_param.id is None:
-            token_to_revoke = token
-        else:
-            token_to_revoke = (
-                session.query(ExecutiveToken)
-                .filter(ExecutiveToken.id == form_param.id)
-                .filter(ExecutiveToken.is_revoked == False)
-                .first()
-            )
-            if token_to_revoke is None:
-                return Response(status_code=status.HTTP_201_CREATED)
-            if token_to_revoke.id != token.id:
-                roles = get_executive_roles(session, token)
-                verify_permission(
-                    roles,
-                    PermissionPath.DELETE_EXECUTIVE_TOKEN,
-                )
+        token_to_delete = (
+            session.query(ExecutiveToken)
+            .filter(ExecutiveToken.id == form_param.id)
+            .filter(ExecutiveToken.is_revoked == False)
+            .first()
+        )
+        if token_to_delete is None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        if token_to_delete.executive_id != token.executive_id:
+            roles = get_executive_roles(session, token)
+            verify_permission(roles, PermissionPath.DELETE_EXECUTIVE_TOKEN)
 
         # Revoke the chosen token
-        token_to_revoke.is_revoked = True
+        token_to_delete.is_revoked = True
         session.commit()
-        session.refresh(token_to_revoke)
+        session.refresh(token_to_delete)
 
-        _, token_log_data = token_to_json(token_to_revoke)
-        log_event(token_to_revoke, request_info, token_log_data)
+        _, token_log_data = token_to_json(token_to_delete)
+        log_event(token_to_delete, request_info, token_log_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -101,7 +101,7 @@ class DeleteForm(BaseModel):
 class LogoutForm(BaseModel):
     """Form data for logging out with an executive token."""
 
-    token: str = Field(Form())
+    token: str = Field(Form(description="Access or refresh token"))
 
 
 ## Query Parameters
@@ -252,10 +252,10 @@ async def revoke_token(
     request_info=Depends(get_request_info),
 ):
     """
-    **Revokes an access token associated with the executive.**
+    **Revokes an access token or refresh token associated with the executive.**
 
     - Verifies that the provided access token exists and is valid.
-    - Logs out the executive by revoking the current access token.
+    - Logs out the executive by revoking the associated access token.
     - If the token is invalid or already revoked, the operation is silently ignored.
     """
 
@@ -266,7 +266,10 @@ async def revoke_token(
         token_to_revoke = (
             session.query(ExecutiveToken)
             .filter(ExecutiveToken.id == token.id)
-            .filter(ExecutiveToken.access_token == form_param.token)
+            .filter(
+                (ExecutiveToken.access_token == form_param.token)
+                | (ExecutiveToken.refresh_token == form_param.token)
+            )
             .filter(ExecutiveToken.is_revoked == False)
             .first()
         )

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -99,7 +99,7 @@ class DeleteForm(BaseModel):
 
 
 class LogoutForm(BaseModel):
-    """Form data for logging out an executive token."""
+    """Form data for logging out with an executive token."""
 
     token: str = Field(Form())
 

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -95,7 +95,7 @@ class UpdateForm(BaseModel):
 class DeleteForm(BaseModel):
     """Form data for deleting an executive token."""
 
-    id: int
+    id: int | None = Field(Form(default=None))
 
 
 ## Query Parameters
@@ -234,10 +234,10 @@ async def refresh_token(
         session.close()
 
 
-@route_executive.delete(
-    URL_EXECUTIVE_TOKEN + "/{id}",
+@route_executive.post(
+    URL_EXECUTIVE_TOKEN + "/revoke",
     tags=["Token"],
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(
         [
             exceptions.InvalidToken(),
@@ -245,7 +245,7 @@ async def refresh_token(
         ]
     ),
 )
-async def delete_token(
+async def revoke_token(
     form_param: DeleteForm = Depends(),
     bearer=Depends(bearer_executive),
     request_info=Depends(get_request_info),
@@ -254,36 +254,40 @@ async def delete_token(
     **Revokes an access token associated with an executive account.**
 
     - Verifies that the provided access token exists and is valid.
-    - If the user lacks permission, only their own current token can be revoked.
-    - If the user has the 'executive.token.delete' permission, the specified token can be deleted.
+    - If no `id` is provided, the currently used token will be revoked.
+    - If an `id` is provided, the specified token will be revoked after validating user permissions 'executive.token.delete'.
     - If the token id is invalid or already revoked, the operation is silently ignored.
     """
 
     try:
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, bearer.credentials)
-        token_to_delete = (
-            session.query(ExecutiveToken)
-            .filter(ExecutiveToken.id == form_param.id)
-            .filter(ExecutiveToken.is_revoked == False)
-            .first()
-        )
-        if token_to_delete is None:
-            return Response(status_code=status.HTTP_204_NO_CONTENT)
-        if token_to_delete.id != token.id:
-            roles = get_executive_roles(session, token)
-            verify_permission(
-                roles,
-                PermissionPath.DELETE_EXECUTIVE_TOKEN,
+
+        if form_param.id is None:
+            token_to_revoke = token
+        else:
+            token_to_revoke = (
+                session.query(ExecutiveToken)
+                .filter(ExecutiveToken.id == form_param.id)
+                .filter(ExecutiveToken.is_revoked == False)
+                .first()
             )
+            if token_to_revoke is None:
+                return Response(status_code=status.HTTP_201_CREATED)
+            if token_to_revoke.id != token.id:
+                roles = get_executive_roles(session, token)
+                verify_permission(
+                    roles,
+                    PermissionPath.DELETE_EXECUTIVE_TOKEN,
+                )
 
         # Revoke the chosen token
-        token_to_delete.is_revoked = True
+        token_to_revoke.is_revoked = True
         session.commit()
-        session.refresh(token_to_delete)
+        session.refresh(token_to_revoke)
 
-        _, token_log_data = token_to_json(token_to_delete)
-        log_event(token_to_delete, request_info, token_log_data)
+        _, token_log_data = token_to_json(token_to_revoke)
+        log_event(token_to_revoke, request_info, token_log_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -95,7 +95,7 @@ class UpdateForm(BaseModel):
 class DeleteForm(BaseModel):
     """Form data for deleting an executive token."""
 
-    id: int | None = Field(Form(default=None))
+    id: int
 
 
 ## Query Parameters
@@ -235,7 +235,7 @@ async def refresh_token(
 
 
 @route_executive.delete(
-    URL_EXECUTIVE_TOKEN,
+    URL_EXECUTIVE_TOKEN + "/{id}",
     tags=["Token"],
     status_code=status.HTTP_204_NO_CONTENT,
     responses=fuse_exception_responses(
@@ -253,35 +253,29 @@ async def delete_token(
     """
     **Revokes an access token associated with an executive account.**
 
-    - Verify that the provided access token exists and is valid.
-    - If no `id` is provided, the currently used token will be revoked.
-    - If an `id` is provided, the specified token will be revoked after validating user permissions 'executive.token.delete'.
+    - Verifies that the provided access token exists and is valid.
+    - If the user lacks permission, only their own current token can be revoked.
+    - If the user has the 'executive.token.delete' permission, the specified token can be deleted.
     - If the token id is invalid or already revoked, the operation is silently ignored.
     """
 
     try:
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, bearer.credentials)
-        if form_param.id is None:
-            token_to_delete = token
-        else:
-            token_to_delete = (
-                session.query(ExecutiveToken)
-                .filter(ExecutiveToken.id == form_param.id)
-                .filter(ExecutiveToken.is_revoked == False)
-                .first()
+        token_to_delete = (
+            session.query(ExecutiveToken)
+            .filter(ExecutiveToken.id == form_param.id)
+            .filter(ExecutiveToken.is_revoked == False)
+            .first()
+        )
+        if token_to_delete is None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        if token_to_delete.id != token.id:
+            roles = get_executive_roles(session, token)
+            verify_permission(
+                roles,
+                PermissionPath.DELETE_EXECUTIVE_TOKEN,
             )
-            if token_to_delete is None:
-                return Response(status_code=status.HTTP_204_NO_CONTENT)
-
-            is_self_delete = token_to_delete.id == token.id
-
-            if not is_self_delete:
-                roles = get_executive_roles(session, token.executive_id)
-                verify_permission(
-                    roles,
-                    PermissionPath.DELETE_EXECUTIVE_TOKEN,
-                )
 
         # Revoke the chosen token
         token_to_delete.is_revoked = True


### PR DESCRIPTION
### **Summary of Changes**

- Modified the openAPI scheme_name with PascalCase.
- Token deletion using a DELETE HTTP request with the resource's identifier in the URL path.
  - If the logged-in executive’s current token ID is provided,
    - The token is revoked and returns 204 No Content.
  - If the logged-in executive provides another executive’s token ID,→ permission executive.token.delete is checked:
    - If permission is missing → 403 Forbidden.
    - If permission is granted, → token revoked and returns 204 No Content.

- Added POST method for logout according to O Auth 2.0 practice.
- If the logged-in executive’s current token is given in token, → the token is revoked and returns 200 OK.
- If the logged-in executive provides another executive’s token or an invalid token or a revoked token, → the request is silently ignored and returns 200 OK.

### **How to Test / Verify**
- Make sure the delete endpoint with the ID is working as expected.
- Make sure the logout is working as expected.

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
