### PR TITLE
Create delete/bus stop endpoint for executive app

### DIFF
--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -397,7 +397,7 @@ async def delete_bus_stop(
         bus_stop = session.query(BusStop).filter(BusStop.id == id).first()
         if bus_stop is not None:
             bus_stop_data = jsonable_encoder(bus_stop, exclude={BusStop.location.name})
-            bus_stop_data[BusStop.location.name] = wkb.loads( 
+            bus_stop_data[BusStop.location.name] = wkb.loads(
                 bytes(bus_stop.location.data)
             ).wkt
             session.delete(bus_stop)
@@ -408,7 +408,7 @@ async def delete_bus_stop(
         exceptions.handle(e)
     finally:
         session.close()
-        
+
 
 @route_executive.get(
     URL_BUS_STOP,

--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -1,10 +1,9 @@
 """
 Bus Stop API Router for EnteBus.
 
-Provides an endpoint for managing bus stops, including creation, 
-update, and deletion. Uses Pydantic schemas for input validation 
-and structured output. Endpoints for retrieval are planned for 
-future implementation.
+Provides endpoints for managing bus stops, including creation,
+update, deletion, and retrieval. Uses Pydantic schemas for
+input validation and structured output.
 """
 
 from datetime import datetime

--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -1,13 +1,14 @@
 """
 Bus Stop API Router for EnteBus.
 
-Provides an endpoint for creating and updating bus stops.
-Uses Pydantic schemas for input validation and structured output.
-Endpoints for deletion and retrieval are planned for future implementation.
+Provides an endpoint for managing bus stops, including creation, 
+update, and deletion. Uses Pydantic schemas for input validation 
+and structured output. Endpoints for retrieval are planned for 
+future implementation.
 """
 
 from datetime import datetime
-from fastapi import APIRouter, status, Depends
+from fastapi import APIRouter, status, Depends,Response
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from shapely.geometry import Point
@@ -242,3 +243,47 @@ async def update_bus_stop(
         exceptions.handle(e)
     finally:
         session.close()
+
+
+@route_executive.delete(
+    f"{URL_BUS_STOP}/{{id}}",
+    tags=["Bus Stop"],
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
+    description=(
+        """
+        **Deletes an existing bus stop.**  
+        - Requires a valid access token for authentication.  
+        - The logged-in executive must have `landmark.bus_stop.delete` permission.  
+        - Returns 204 No Content even if the specified bus stop does not exist.  
+        """
+    ),
+)
+async def delete_bus_stop(
+    id: int,
+    access_token=Depends(oauth2_executive),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, ExecutiveToken, access_token)
+        roles = get_executive_roles(session, token)
+        verify_permission(roles, PermissionPath.DELETE_BUS_STOP)
+
+        bus_stop = session.query(BusStop).filter(BusStop.id == id).first()
+        if bus_stop is not None:
+            bus_stop_data = jsonable_encoder(bus_stop, exclude={BusStop.location.name})
+            bus_stop_data[BusStop.location.name] = wkb.loads( 
+                bytes(bus_stop.location.data)
+            ).wkt
+            session.delete(bus_stop)
+            session.commit()
+            log_event(token, request_info, bus_stop_data)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+        

--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -8,7 +8,7 @@ future implementation.
 """
 
 from datetime import datetime
-from fastapi import APIRouter, status, Depends,Response
+from fastapi import APIRouter, Response, status, Depends
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from shapely.geometry import Point


### PR DESCRIPTION
### **Summary of Changes**

- Added DELETE /landmark/bus_stop/{id} endpoint.
- Validates executive token before execution.
- Checks landmark.bus_stop.delete permission.
- Returns 204 No Content (even if bus stop does not exist).
- Logs deletion event on success.
- Removed generic function orm_to_json and used jsonable_encoder in all endpoints

### **How to Test / Verify**
- Call DELETE with valid token + permission → expect 204.
- Use invalid token → expect 401 InvalidToken.
- Use token without permission → expect 403 NoPermission.
- Delete non-existing ID → still 204


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
