### PR TITLE
Create delete operator token for operator and executive app

### DIFF
--- a/app/api/controller.py
+++ b/app/api/controller.py
@@ -57,9 +57,9 @@ app_vendor.include_router(bus_stop.route_vendor)
 # ------------------------------------------------------
 # Operator routers
 # ------------------------------------------------------
+app_operator.include_router(operator_token.route_operator)
 app_operator.include_router(landmark.route_operator)
 app_operator.include_router(bus_stop.route_operator)
-app_operator.include_router(operator_token.route_operator)
 
 
 # ------------------------------------------------------

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -236,7 +236,7 @@ async def refresh_token(
         token_log_data = token_data.copy()
         token_log_data.pop(ExecutiveToken.access_token.name)
         token_log_data.pop(ExecutiveToken.refresh_token.name)
-        log_event(refresh_token, request_info, token_log_data)
+        log_event(token, request_info, token_log_data)
         return token_data
     except Exception as e:
         exceptions.handle(e)
@@ -283,7 +283,7 @@ async def revoke_token(
             token_log_data = jsonable_encoder(token_to_revoke)
             token_log_data.pop(ExecutiveToken.access_token.name)
             token_log_data.pop(ExecutiveToken.refresh_token.name)
-            log_event(token_to_revoke, request_info, token_log_data)
+            log_event(token, request_info, token_log_data)
 
         return Response(status_code=status.HTTP_200_OK)
     except Exception as e:

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -338,7 +338,7 @@ async def delete_token(
         token_log_data = jsonable_encoder(token_to_delete)
         token_log_data.pop(ExecutiveToken.access_token.name)
         token_log_data.pop(ExecutiveToken.refresh_token.name)
-        log_event(token_to_delete, request_info, token_log_data)
+        log_event(token, request_info, token_log_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -2,14 +2,14 @@
 Operator Token API Router for EnteBus.
 
 Provides an endpoint for managing operator access tokens, including creation,
-refresh, and retrieval. Uses Pydantic schemas for input validation
-and structured output. Endpoints for deletion are planned for future implementation.
+refresh, deletion, and retrieval. Uses Pydantic schemas for
+input validation and structured output.
 """
 
 from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import List, Optional
-from fastapi import APIRouter, Depends, Form, Query
+from fastapi import APIRouter, Depends, Form, Query, Response, status
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from fastapi.security import OAuth2PasswordRequestForm
@@ -336,6 +336,70 @@ async def fetch_tokens_operator(
         session.close()
 
 
+@route_operator.delete(
+    f"{URL_OPERATOR_TOKEN}/{{id}}",
+    tags=["Token"],
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
+    description=(
+        """
+            **Deletes an operator access token.**    
+            - Operator must have a valid access token.    
+            - Operators can delete their own tokens without additional permissions.    
+            - To delete another operator's token in the same company,  
+              the 'company.operator.token.delete' permission is required.    
+            - If the token ID is invalid or already revoked, the operation is silently ignored.    
+        """
+    ),
+)
+async def delete_token_operator(
+    id: int,
+    access_token=Depends(bearer_operator),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, OperatorToken, access_token.credentials)
+
+        token_to_delete = (
+            session.query(OperatorToken)
+            .filter(OperatorToken.id == id)
+            .filter(OperatorToken.is_revoked.is_(False))
+            .first()
+        )
+
+        if token_to_delete is None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        if token_to_delete.company_id != token.company_id:
+            raise exceptions.NoPermission()
+
+        if token_to_delete.operator_id != token.operator_id:
+            roles = get_operator_roles(session, token)
+            verify_permission(
+                roles,
+                OperatorPermissionPath.DELETE_COMPANY_OPERATOR_TOKEN,
+            )
+
+        # Revoke token
+        token_to_delete.is_revoked = True
+        session.commit()
+        session.refresh(token_to_delete)
+
+        token_log_data = jsonable_encoder(token_to_delete)
+        token_log_data.pop(OperatorToken.access_token.name)
+        token_log_data.pop(OperatorToken.refresh_token.name)
+        log_event(token_to_delete, request_info, token_log_data)
+
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
 # ---------------------------------------------------------------------------
 ## API endpoints [Executive]
 # ---------------------------------------------------------------------------
@@ -373,6 +437,66 @@ async def fetch_tokens_executive(
             raise exceptions.NoPermission()
 
         return search_operator_tokens(session, query_params)
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_executive.delete(
+    f"{URL_OPERATOR_TOKEN}/{{id}}",
+    tags=["Operator Token"],
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
+    description=(
+        """
+            **Deletes an operator access token.**    
+            - Executive must have a valid access token.    
+            - Executive must have 'company.operator.token.delete' permission.    
+            - Executive can delete any operator's token.    
+            - If the token ID is invalid or already revoked, the operation is silently ignored.    
+        """
+    ),
+)
+async def delete_token_executive(
+    id: int,
+    access_token=Depends(oauth2_executive),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, ExecutiveToken, access_token)
+
+        roles = get_executive_roles(session, token)
+        verify_permission(
+            roles,
+            ExecutivePermissionPath.DELETE_COMPANY_OPERATOR_TOKEN,
+        )
+
+        token_to_delete = (
+            session.query(OperatorToken)
+            .filter(OperatorToken.id == id)
+            .filter(OperatorToken.is_revoked.is_(False))
+            .first()
+        )
+
+        if token_to_delete is None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+        # Revoke token
+        token_to_delete.is_revoked = True
+        session.commit()
+        session.refresh(token_to_delete)
+
+        token_log_data = jsonable_encoder(token_to_delete)
+        token_log_data.pop(OperatorToken.access_token.name)
+        token_log_data.pop(OperatorToken.refresh_token.name)
+        log_event(token, request_info, token_log_data)
+
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -282,7 +282,7 @@ async def refresh_token(
         token_log_data = token_data.copy()
         token_log_data.pop(OperatorToken.access_token.name)
         token_log_data.pop(OperatorToken.refresh_token.name)
-        log_event(refresh_token, request_info, token_log_data)
+        log_event(token, request_info, token_log_data)
         return token_data
     except Exception as e:
         exceptions.handle(e)
@@ -370,12 +370,13 @@ async def delete_token_operator(
             .filter(OperatorToken.is_revoked.is_(False))
             .first()
         )
-
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
         if token_to_delete.operator_id != token.operator_id:
             roles = get_operator_roles(session, token)
-            verify_permission(roles, OperatorPermissionPath.DELETE_COMPANY_OPERATOR_TOKEN)
+            verify_permission(
+                roles, OperatorPermissionPath.DELETE_COMPANY_OPERATOR_TOKEN
+            )
 
         # Revoke token
         token_to_delete.is_revoked = True
@@ -386,9 +387,7 @@ async def delete_token_operator(
         token_log_data.pop(OperatorToken.access_token.name)
         token_log_data.pop(OperatorToken.refresh_token.name)
         log_event(token, request_info, token_log_data)
-
         return Response(status_code=status.HTTP_204_NO_CONTENT)
-
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -485,9 +484,7 @@ async def delete_token_executive(
         token_log_data.pop(OperatorToken.access_token.name)
         token_log_data.pop(OperatorToken.refresh_token.name)
         log_event(token, request_info, token_log_data)
-
         return Response(status_code=status.HTTP_204_NO_CONTENT)
-
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -390,7 +390,7 @@ async def delete_token_operator(
         token_log_data = jsonable_encoder(token_to_delete)
         token_log_data.pop(OperatorToken.access_token.name)
         token_log_data.pop(OperatorToken.refresh_token.name)
-        log_event(token_to_delete, request_info, token_log_data)
+        log_event(token, request_info, token_log_data)
 
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -366,21 +366,16 @@ async def delete_token_operator(
         token_to_delete = (
             session.query(OperatorToken)
             .filter(OperatorToken.id == id)
+            .filter(OperatorToken.company_id == token.company_id)
             .filter(OperatorToken.is_revoked.is_(False))
             .first()
         )
 
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
-        if token_to_delete.company_id != token.company_id:
-            raise exceptions.NoPermission()
-
         if token_to_delete.operator_id != token.operator_id:
             roles = get_operator_roles(session, token)
-            verify_permission(
-                roles,
-                OperatorPermissionPath.DELETE_COMPANY_OPERATOR_TOKEN,
-            )
+            verify_permission(roles, OperatorPermissionPath.DELETE_COMPANY_OPERATOR_TOKEN)
 
         # Revoke token
         token_to_delete.is_revoked = True
@@ -468,12 +463,8 @@ async def delete_token_executive(
     try:
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, access_token)
-
         roles = get_executive_roles(session, token)
-        verify_permission(
-            roles,
-            ExecutivePermissionPath.DELETE_COMPANY_OPERATOR_TOKEN,
-        )
+        verify_permission(roles, ExecutivePermissionPath.DELETE_COMPANY_OPERATOR_TOKEN)
 
         token_to_delete = (
             session.query(OperatorToken)


### PR DESCRIPTION
### **Summary of Changes**
- Added new DELETE /operator_token/{id} endpoint across Operator and Executive.
- Checks company.operator.token.delete permission.
- Returns 204 No Content (even if operator_token does not exist).
- Logs deletion event on success.
### **How to Test / Verify**
- Call DELETE with valid token + permission → expect 204.
- Use invalid token → expect 401 InvalidToken.
- Use token without permission → expect 403 NoPermission.
- Delete non-existing ID → still 204


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A

### **Reviewer Notes**
N/A
