### PR TITLE
Create post endpoint for operator token revoke.

### DIFF
--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -280,6 +280,7 @@ async def revoke_token(
             token_to_revoke.is_revoked = True
             session.commit()
             session.refresh(token_to_revoke)
+            
             token_log_data = jsonable_encoder(token_to_revoke)
             token_log_data.pop(ExecutiveToken.access_token.name)
             token_log_data.pop(ExecutiveToken.refresh_token.name)

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -98,6 +98,12 @@ class UpdateForm(BaseModel):
     )
 
 
+class LogoutForm(BaseModel):
+    """Form data for logging out with an operator token."""
+
+    token: str = Field(Form(description="Access or refresh token"))
+
+
 ## Query Parameters
 class OrderBy(StrEnum):
     """Enum for ordering results."""
@@ -284,6 +290,53 @@ async def refresh_token(
         token_log_data.pop(OperatorToken.refresh_token.name)
         log_event(token, request_info, token_log_data)
         return token_data
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_operator.post(
+    f"{URL_OPERATOR_TOKEN}/revoke",
+    tags=["Token"],
+    responses=fuse_exception_responses([exceptions.InvalidToken()]),
+    description=(
+        """
+            **Revokes an access token or refresh token associated with the operator.**     
+            - Operator must have a valid access token.     
+            - Revokes the token (access or refresh) specified in the request body.      
+            - If the token is invalid, doesn't belong to the operator, or is already revoked, the operation is silently ignored.       
+        """
+    ),
+)
+async def revoke_token(
+    form_param: LogoutForm = Depends(),
+    access_token=Depends(bearer_operator),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, OperatorToken, access_token.credentials)
+
+        token_to_revoke = (
+            session.query(OperatorToken)
+            .filter(OperatorToken.operator_id == token.operator_id)
+            .filter(
+                (OperatorToken.access_token == form_param.token)
+                | (OperatorToken.refresh_token == form_param.token)
+            )
+            .filter(OperatorToken.is_revoked.is_(False))
+            .first()
+        )
+        if token_to_revoke:
+            token_to_revoke.is_revoked = True
+            session.commit()
+            session.refresh(token_to_revoke)
+            token_log_data = jsonable_encoder(token_to_revoke)
+            token_log_data.pop(OperatorToken.access_token.name)
+            token_log_data.pop(OperatorToken.refresh_token.name)
+            log_event(token, request_info, token_log_data)
+        return Response(status_code=status.HTTP_200_OK)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -332,6 +332,7 @@ async def revoke_token(
             token_to_revoke.is_revoked = True
             session.commit()
             session.refresh(token_to_revoke)
+            
             token_log_data = jsonable_encoder(token_to_revoke)
             token_log_data.pop(OperatorToken.access_token.name)
             token_log_data.pop(OperatorToken.refresh_token.name)


### PR DESCRIPTION
### **Summary of Changes**
- Added `post`  method to revoke an operator token.

### **How to Test / Verify**
- Verify the specified token is marked as revoked in the database.
- Verify revoked tokens can no longer be used for authentication.
- Verify the endpoint returns 200 even if the token is invalid, already revoked, or does not belong to the operator.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
