### PR TITLE
Create DELETE endpoint for vendor access token management

### DIFF
--- a/app/api/controller.py
+++ b/app/api/controller.py
@@ -48,7 +48,7 @@ app_executive.include_router(landmark.route_executive)
 app_executive.include_router(bus_stop.route_executive)
 app_executive.include_router(operator_token.route_executive)
 app_executive.include_router(company.route_executive)
-
+app_executive.include_router(vendor_token.route_executive)
 
 # ------------------------------------------------------
 # Vendor routers

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -530,7 +530,6 @@ async def delete_token_executive(
             .filter(OperatorToken.is_revoked.is_(False))
             .first()
         )
-
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -528,7 +528,6 @@ async def delete_token_executive(
             .filter(VendorToken.is_revoked.is_(False))
             .first()
         )
-
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -13,8 +13,10 @@ from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from fastapi.security import OAuth2PasswordRequestForm
 
-from app.api.bearer import bearer_vendor
-from app.src.db import Vendor, VendorToken, SessionLocal
+from app.api.bearer import bearer_vendor, oauth2_executive
+from app.src.permissions.vendor import PermissionPath as VendorPermissionPath
+from app.src.permissions.executive import PermissionPath as ExecutivePermissionPath
+from app.src.db import Vendor, VendorToken, ExecutiveToken, SessionLocal
 from app.src import exceptions
 from app.src.enums import PlatformType, GrantType
 from app.src.openobserve import log_event
@@ -28,15 +30,19 @@ from app.src.validators import (
     authenticate_vendor,
     validate_and_revoke_refresh_token,
     verify_token,
+    verify_permission,
 )
 from app.src.functions import (
     cleanup_old_tokens,
     enum_str,
     fuse_exception_responses,
     get_request_info,
+    get_vendor_roles,
+    get_executive_roles,
 )
 
 route_vendor = APIRouter()
+route_executive = APIRouter()
 
 
 # Output Schema
@@ -260,6 +266,119 @@ async def revoke_token(
             token_log_data.pop(VendorToken.refresh_token.name)
             log_event(token, request_info, token_log_data)
         return Response(status_code=status.HTTP_200_OK)
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_vendor.delete(
+    f"{URL_VENDOR_TOKEN}/{{id}}",
+    tags=["Token"],
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
+    description=(
+        """
+            **Deletes a vendor access token.**    
+            - Vendor must have a valid access token.    
+            - Vendors can delete their own tokens without additional permissions.    
+            - To delete another vendor's token in the same business,  
+              the 'business.vendor.token.delete' permission is required.    
+            - If the token ID is invalid or already revoked, the operation is silently ignored.    
+        """
+    ),
+)
+async def delete_token_vendor(
+    id: int,
+    access_token=Depends(bearer_vendor),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, VendorToken, access_token.credentials)
+
+        token_to_delete = (
+            session.query(VendorToken)
+            .filter(VendorToken.id == id)
+            .filter(VendorToken.business_id == token.business_id)
+            .filter(VendorToken.is_revoked.is_(False))
+            .first()
+        )
+        if token_to_delete is None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        if token_to_delete.vendor_id != token.vendor_id:
+            roles = get_vendor_roles(session, token)
+            verify_permission(roles, VendorPermissionPath.DELETE_BUSINESS_VENDOR_TOKEN)
+
+        # Revoke token
+        token_to_delete.is_revoked = True
+        session.commit()
+        session.refresh(token_to_delete)
+
+        token_log_data = jsonable_encoder(token_to_delete)
+        token_log_data.pop(VendorToken.access_token.name)
+        token_log_data.pop(VendorToken.refresh_token.name)
+        log_event(token, request_info, token_log_data)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+## API endpoints [Executive]
+# ---------------------------------------------------------------------------
+@route_executive.delete(
+    f"{URL_VENDOR_TOKEN}/{{id}}",
+    tags=["Vendor Token"],
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
+    description=(
+        """
+            **Deletes a vendor access token.**    
+            - Executive must have a valid access token.    
+            - Executive must have 'business.vendor.token.delete' permission.    
+            - Executive can delete any vendor's token.    
+            - If the token ID is invalid or already revoked, the operation is silently ignored.    
+        """
+    ),
+)
+async def delete_token_executive(
+    id: int,
+    access_token=Depends(oauth2_executive),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, ExecutiveToken, access_token)
+        roles = get_executive_roles(session, token)
+        verify_permission(roles, ExecutivePermissionPath.DELETE_BUSINESS_VENDOR_TOKEN)
+
+        token_to_delete = (
+            session.query(VendorToken)
+            .filter(VendorToken.id == id)
+            .filter(VendorToken.is_revoked.is_(False))
+            .first()
+        )
+
+        if token_to_delete is None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+        # Revoke token
+        token_to_delete.is_revoked = True
+        session.commit()
+        session.refresh(token_to_delete)
+
+        token_log_data = jsonable_encoder(token_to_delete)
+        token_log_data.pop(VendorToken.access_token.name)
+        token_log_data.pop(VendorToken.refresh_token.name)
+        log_event(token, request_info, token_log_data)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -395,49 +395,6 @@ async def fetch_tokens_vendor(
         session.close()
 
 
-# ---------------------------------------------------------------------------
-## API endpoints [Executive]
-# ---------------------------------------------------------------------------
-@route_executive.get(
-    URL_VENDOR_TOKEN,
-    tags=["Vendor Token"],
-    response_model=list[MaskedVendorTokenSchema],
-    responses=fuse_exception_responses(
-        [
-            exceptions.InvalidToken(),
-            exceptions.NoPermission(),
-        ]
-    ),
-    description=(
-        """
-            **Fetch vendor tokens with permission-based filtering.**     
-            - If the logged-in executive has `business.vendor.token.fetch` permission, all masked tokens are returned.    
-            - If the logged-in executive does not have permission, they cannot access this endpoint.     
-        """
-    ),
-)
-async def fetch_tokens_executive(
-    query_params: QueryParams = Depends(),
-    access_token=Depends(oauth2_executive),
-):
-    try:
-        session = SessionLocal()
-        token = verify_token(session, ExecutiveToken, access_token)
-        roles = get_executive_roles(session, token)
-        has_permission = verify_permission(
-            roles, ExecutivePermissionPath.FETCH_BUSINESS_VENDOR_TOKEN, False
-        )
-
-        if has_permission is False:
-            raise exceptions.NoPermission()
-
-        return search_vendor_tokens(session, query_params)
-    except Exception as e:
-        exceptions.handle(e)
-    finally:
-        session.close()
-
-
 @route_vendor.delete(
     f"{URL_VENDOR_TOKEN}/{{id}}",
     tags=["Token"],
@@ -497,6 +454,46 @@ async def delete_token_vendor(
 # ---------------------------------------------------------------------------
 ## API endpoints [Executive]
 # ---------------------------------------------------------------------------
+@route_executive.get(
+    URL_VENDOR_TOKEN,
+    tags=["Vendor Token"],
+    response_model=list[MaskedVendorTokenSchema],
+    responses=fuse_exception_responses(
+        [
+            exceptions.InvalidToken(),
+            exceptions.NoPermission(),
+        ]
+    ),
+    description=(
+        """
+            **Fetch vendor tokens with permission-based filtering.**     
+            - If the logged-in executive has `business.vendor.token.fetch` permission, all masked tokens are returned.    
+            - If the logged-in executive does not have permission, they cannot access this endpoint.     
+        """
+    ),
+)
+async def fetch_tokens_executive(
+    query_params: QueryParams = Depends(),
+    access_token=Depends(oauth2_executive),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, ExecutiveToken, access_token)
+        roles = get_executive_roles(session, token)
+        has_permission = verify_permission(
+            roles, ExecutivePermissionPath.FETCH_BUSINESS_VENDOR_TOKEN, False
+        )
+
+        if has_permission is False:
+            raise exceptions.NoPermission()
+
+        return search_vendor_tokens(session, query_params)
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
 @route_executive.delete(
     f"{URL_VENDOR_TOKEN}/{{id}}",
     tags=["Vendor Token"],


### PR DESCRIPTION
### **Summary of Changes**
- Added new DELETE /vendor_token/{id} endpoint across Vendor and Executive.
- Checks business.vendor.token.delete permission.
- Returns 204 No Content (even if vendor_token does not exist).
- Logs deletion event on success.
### **How to Test / Verify**
- Call DELETE with valid token + permission → expect 204.
- Use invalid token → expect 401 InvalidToken.
- Use token without permission → expect 403 NoPermission.
- Delete non-existing ID → still 204


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A

### **Reviewer Notes**
N/A
