### PR TITLE
Fix token permission handling.

### DIFF
--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -338,7 +338,7 @@ async def update_bus_stop(
 
         update_data = form_param.model_dump(exclude_unset=True)
         if form_param.location is not None:
-            # Validate location (WKT, SRID, and landmark boundary)
+            # Validate location if changed
             new_geom = validate_location(
                 session, form_param.location, bus_stop.landmark_id
             )

--- a/app/api/company.py
+++ b/app/api/company.py
@@ -142,7 +142,6 @@ def update_company(
 ) -> Tuple[bool, dict]:
 
     update_data = form_param.model_dump(exclude_unset=True)
-    print("Update data:", update_data)
     # Validate location if changed
     if form_param.location is not None:
         new_geom = validate_location(form_param.location)

--- a/app/api/company.py
+++ b/app/api/company.py
@@ -7,11 +7,13 @@ Endpoints for deletion, and retrieval are planned for future implementation.
 """
 
 from datetime import datetime
+from typing import Tuple
 from fastapi import APIRouter, status, Depends
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from shapely import wkb, wkt
 from shapely.geometry import Point
+from sqlalchemy.orm.session import Session
 
 from app.api.bearer import oauth2_executive, bearer_operator
 from app.src.db import (
@@ -53,6 +55,7 @@ class CompanySchema(BaseModel):
     name: str
     status: int
     type: int
+    description: str | None
     address: str
     location: str
     updated_on: datetime | None
@@ -84,8 +87,8 @@ class UpdateFormForOP(BaseModel):
     """Form for updating a company by operator."""
 
     description: str | None = Field(default=None, min_length=1, max_length=1024)
-    address: str | None = Field(default=None, min_length=1, max_length=512)
-    location: str | None = Field(
+    address: str = Field(default=None, min_length=1, max_length=512)
+    location: str = Field(
         default=None,
         description=(
             f"Accepts only SRID 4326 (WGS84), "
@@ -97,17 +100,89 @@ class UpdateFormForOP(BaseModel):
 class UpdateFormForEX(UpdateFormForOP):
     """Form for updating a company by executive."""
 
-    name: str | None = Field(
+    name: str = Field(
         min_length=1, max_length=32, pattern=NAME_PATTERN, default=None
     )
-    status: CompanyStatus | None = Field(
+    status: CompanyStatus = Field(
         description=enum_str(CompanyStatus),
         default=None,
     )
-    type: CompanyType | None = Field(
+    type: CompanyType = Field(
         description=enum_str(CompanyType),
         default=None,
     )
+
+
+class UpdateForm(UpdateFormForEX):
+    """Form for updating a company by executive or operator."""
+
+    pass
+
+
+# Function
+def validate_location(location_wkt: str) -> Point:
+    """
+    Validate a WKT string as a Point geometry with SRID 4326.
+
+    Args:
+        location_wkt (str): Location in WKT format (Point geometry).
+
+    Returns:
+        Point: Validated Shapely `Point` geometry.
+    """
+    # Validate WKT and SRID
+    location_geom = validate_wkt_string(location_wkt, Point)
+    validate_srid_4326(location_geom)
+
+    return location_geom
+
+
+def update_company(
+    session: Session, company: Company, form_param: UpdateForm
+) -> Tuple[bool, dict]:
+
+    update_data = form_param.model_dump(exclude_unset=True)
+    print("Update data:", update_data)
+    # Validate location if changed
+    if form_param.location is not None:
+        new_geom = validate_location(form_param.location)
+        old_geom = wkb.loads(bytes(company.location.data))
+
+        if new_geom.wkt != old_geom.wkt:
+            company.location = wkt.dumps(new_geom)
+        update_data.pop("location")
+
+    wallet = None
+    if form_param.name is not None:
+        if form_param.name != company.name:
+            company.name = form_param.name
+            company_wallet = (
+                session.query(CompanyWallet)
+                .filter(CompanyWallet.company_id == company.id)
+                .first()
+            )
+            wallet = (
+                session.query(Wallet)
+                .filter(Wallet.id == company_wallet.wallet_id)
+                .first()
+            )
+            wallet.name = form_param.name
+        update_data.pop("name")
+
+    update_if_changed(company, update_data)
+    have_updates = session.is_modified(company) or (
+        wallet and session.is_modified(wallet)
+    )
+    if have_updates:
+        session.commit()
+        session.refresh(company)
+
+    company_data = jsonable_encoder(
+        company,
+        exclude={Company.location.name},
+    )
+    company_data[Company.location.name] = (wkb.loads(bytes(company.location.data))).wkt
+    return have_updates, company_data
 
 
 # ---------------------------------------------------------------------------
@@ -148,9 +223,8 @@ async def create_company(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.CREATE_COMPANY)
 
-        # Validate WKT and SRID
-        location_geom = validate_wkt_string(form_param.location, Point)
-        validate_srid_4326(location_geom)
+        # Validate location (WKT and SRID)
+        location_geom = validate_location(form_param.location)
         validated_location = wkt.dumps(location_geom)
 
         company = Company(
@@ -223,50 +297,10 @@ async def update_company_executive(
         verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY)
 
         company = validate_company_id(session, id)
-
-        update_data = form_param.model_dump(exclude_unset=True)
-        # Validate location if changed
-        if form_param.location is not None:
-            new_geom = validate_wkt_string(form_param.location, Point)
-            validate_srid_4326(new_geom)
-            old_geom = wkb.loads(bytes(company.location.data))
-
-            if new_geom.wkt != old_geom.wkt:
-                company.location = wkt.dumps(new_geom)
-            update_data.pop("location")
-
-        wallet = None
-        if form_param.name is not None:
-            if form_param.name != company.name:
-                company.name = form_param.name
-                company_wallet = (
-                    session.query(CompanyWallet)
-                    .filter(CompanyWallet.company_id == company.id)
-                    .first()
-                )
-                wallet = (
-                    session.query(Wallet)
-                    .filter(Wallet.id == company_wallet.wallet_id)
-                    .first()
-                )
-                wallet.name = form_param.name
-            update_data.pop("name")
-
-        update_if_changed(company, update_data)
-        have_updates = session.is_modified(company) or (
-            wallet and session.is_modified(wallet)
+        have_updates, company_data = update_company(
+            session, company, UpdateForm(**form_param.model_dump(exclude_unset=True))
         )
-        if have_updates:
-            session.commit()
-            session.refresh(company)
 
-        company_data = jsonable_encoder(
-            company,
-            exclude={Company.location.name},
-        )
-        company_data[Company.location.name] = (
-            wkb.loads(bytes(company.location.data))
-        ).wkt
         if have_updates:
             log_event(token, request_info, company_data)
         return company_data
@@ -317,31 +351,10 @@ async def update_company_operator(
         company = validate_company_id(session, id)
         if token.company_id != company.id:
             raise exceptions.NoPermission()
-
-        update_data = form_param.model_dump(exclude_unset=True)
-        # Validate location if changed
-        if form_param.location is not None:
-            new_geom = validate_wkt_string(form_param.location, Point)
-            validate_srid_4326(new_geom)
-            old_geom = wkb.loads(bytes(company.location.data))
-
-            if new_geom.wkt != old_geom.wkt:
-                company.location = wkt.dumps(new_geom)
-            update_data.pop("location")
-
-        update_if_changed(company, update_data)
-        have_updates = session.is_modified(company)
-        if have_updates:
-            session.commit()
-            session.refresh(company)
-
-        company_data = jsonable_encoder(
-            company,
-            exclude={Company.location.name},
+        have_updates, company_data = update_company(
+            session, company, UpdateForm(**form_param.model_dump(exclude_unset=True))
         )
-        company_data[Company.location.name] = (
-            wkb.loads(bytes(company.location.data))
-        ).wkt
+
         if have_updates:
             log_event(token, request_info, company_data)
         return company_data

--- a/app/api/executive_account.py
+++ b/app/api/executive_account.py
@@ -219,6 +219,7 @@ async def update_account(
         executive = session.query(Executive).filter(Executive.id == id).first()
         if executive is None:
             raise exceptions.UnknownValue(Executive.id)
+        
         update_data = form_param.model_dump(exclude_unset=True)
         is_self_update = executive.id == token.executive_id
         if not is_self_update:

--- a/app/api/executive_account.py
+++ b/app/api/executive_account.py
@@ -219,7 +219,7 @@ async def update_account(
         executive = session.query(Executive).filter(Executive.id == id).first()
         if executive is None:
             raise exceptions.UnknownValue(Executive.id)
-        
+
         update_data = form_param.model_dump(exclude_unset=True)
         is_self_update = executive.id == token.executive_id
         if not is_self_update:
@@ -240,7 +240,7 @@ async def update_account(
                 .update({ExecutiveToken.is_revoked: True})
                 > 0
             )
-        
+
         update_if_changed(executive, update_data)
         have_updates = session.is_modified(executive) or tokens_revoked
         if have_updates:

--- a/app/api/executive_account.py
+++ b/app/api/executive_account.py
@@ -240,6 +240,7 @@ async def update_account(
                 .update({ExecutiveToken.is_revoked: True})
                 > 0
             )
+        
         update_if_changed(executive, update_data)
         have_updates = session.is_modified(executive) or tokens_revoked
         if have_updates:

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -306,7 +306,8 @@ async def revoke_token(
             - Executive must have a valid access token.    
             - Executives can delete their own tokens without additional permissions.    
             - To delete another executive's token, the 'executive.token.delete' permission is required.    
-            - If the token ID is invalid or already revoked, the operation is silently ignored.    
+            - without permission, trying to delete another executive's token or an invalid token ID will result in a `NoPermission` error.    
+            - If the executive has permission and the token ID is invalid or already revoked, the operation is silently ignored.    
         """
     ),
 )
@@ -318,6 +319,11 @@ async def delete_token(
     try:
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, access_token)
+        has_permission = verify_permission(
+            get_executive_roles(session, token),
+            PermissionPath.DELETE_EXECUTIVE_TOKEN,
+            False,
+        )
 
         token_to_delete = (
             session.query(ExecutiveToken)
@@ -325,11 +331,14 @@ async def delete_token(
             .filter(ExecutiveToken.is_revoked.is_(False))
             .first()
         )
+        if not has_permission:
+            if (
+                token_to_delete is None
+                or token_to_delete.executive_id != token.executive_id
+            ):
+                raise exceptions.NoPermission()
         if token_to_delete is None:
-            return Response(status_code=status.HTTP_204_NO_CONTENT)
-        if token_to_delete.executive_id != token.executive_id:
-            roles = get_executive_roles(session, token)
-            verify_permission(roles, PermissionPath.DELETE_EXECUTIVE_TOKEN)
+            raise exceptions.InvalidToken()
 
         # Revoke the chosen token
         token_to_delete.is_revoked = True

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -306,8 +306,8 @@ async def revoke_token(
             - Executive must have a valid access token.    
             - Executives can delete their own tokens without additional permissions.    
             - To delete another executive's token, the 'executive.token.delete' permission is required.    
-            - without permission, trying to delete another executive's token or an invalid token ID will result in a `NoPermission` error.    
-            - If the executive has permission and the token ID is invalid or already revoked, the operation is silently ignored.    
+            - Trying to delete another executive's token without the required permission will result in a `NoPermission` error.    
+            - If the token ID is invalid or already revoked, the operation is silently ignored.    
         """
     ),
 )

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -377,7 +377,7 @@ async def fetch_token(
         )
 
         query = session.query(ExecutiveToken).filter(ExecutiveToken.is_revoked == False)
-        if has_permission is False:
+        if not :
             if (
                 query_params.executive_id is not None
                 and query_params.executive_id != token.executive_id

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -351,7 +351,9 @@ async def delete_token(
     URL_EXECUTIVE_TOKEN,
     tags=["Token"],
     response_model=list[MaskedExecutiveTokenSchema],
-    responses=fuse_exception_responses([exceptions.InvalidToken()]),
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
     description=(
         """
             **Fetch executive tokens with permission-based filtering.**     
@@ -375,14 +377,10 @@ async def fetch_token(
         )
 
         query = session.query(ExecutiveToken).filter(ExecutiveToken.is_revoked == False)
-        if query_params.executive_id is not None:
-            query = query.filter(
-                ExecutiveToken.executive_id == query_params.executive_id
-            )
         if has_permission is False:
             if (
-                query_params.executive_id is None
-                or query_params.executive_id != token.executive_id
+                query_params.executive_id is not None
+                and query_params.executive_id != token.executive_id
             ):
                 raise exceptions.NoPermission()
 

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -377,7 +377,7 @@ async def fetch_token(
         )
 
         query = session.query(ExecutiveToken).filter(ExecutiveToken.is_revoked == False)
-        if not :
+        if not has_permission:
             if (
                 query_params.executive_id is not None
                 and query_params.executive_id != token.executive_id

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -319,8 +319,9 @@ async def delete_token(
     try:
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, access_token)
+        roles = get_executive_roles(session, token)
         has_permission = verify_permission(
-            get_executive_roles(session, token),
+            roles,
             PermissionPath.DELETE_EXECUTIVE_TOKEN,
             False,
         )
@@ -331,14 +332,10 @@ async def delete_token(
             .filter(ExecutiveToken.is_revoked.is_(False))
             .first()
         )
-        if not has_permission:
-            if (
-                token_to_delete is None
-                or token_to_delete.executive_id != token.executive_id
-            ):
-                raise exceptions.NoPermission()
         if token_to_delete is None:
             raise exceptions.InvalidToken()
+        if not has_permission and token_to_delete.executive_id != token.executive_id:
+            raise exceptions.NoPermission()
 
         # Revoke the chosen token
         token_to_delete.is_revoked = True

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -333,7 +333,7 @@ async def delete_token(
             .first()
         )
         if token_to_delete is None:
-            raise exceptions.InvalidToken()
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
         if not has_permission and token_to_delete.executive_id != token.executive_id:
             raise exceptions.NoPermission()
 

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -384,12 +384,9 @@ async def fetch_token(
 
         query = session.query(ExecutiveToken).filter(ExecutiveToken.is_revoked == False)
         if not has_permission:
-            if (
-                query_params.executive_id is not None
-                and query_params.executive_id != token.executive_id
-            ):
+            if query_params.executive_id not in (None, token.executive_id):
                 raise exceptions.NoPermission()
-
+            # Restrict to only the logged-in executive's tokens
             query = query.filter(ExecutiveToken.executive_id == token.executive_id)
 
         # Generalized filters

--- a/app/api/executive_token.py
+++ b/app/api/executive_token.py
@@ -280,7 +280,7 @@ async def revoke_token(
             token_to_revoke.is_revoked = True
             session.commit()
             session.refresh(token_to_revoke)
-            
+
             token_log_data = jsonable_encoder(token_to_revoke)
             token_log_data.pop(ExecutiveToken.access_token.name)
             token_log_data.pop(ExecutiveToken.refresh_token.name)
@@ -380,6 +380,12 @@ async def fetch_token(
                 ExecutiveToken.executive_id == query_params.executive_id
             )
         if has_permission is False:
+            if (
+                query_params.executive_id is None
+                or query_params.executive_id != token.executive_id
+            ):
+                raise exceptions.NoPermission()
+
             query = query.filter(ExecutiveToken.executive_id == token.executive_id)
 
         # Generalized filters

--- a/app/api/landmark.py
+++ b/app/api/landmark.py
@@ -310,10 +310,13 @@ async def create_landmark(
         roles = get_executive_roles(session, token)
         verify_permission(roles, PermissionPath.CREATE_LANDMARK)
 
-        validate_boundary(session, form_param.boundary)
+        # Validate boundary (WKT, SRID, AABB, Area, Overlaps)
+        boundary_geom = validate_boundary(session, form_param.boundary)
+        validated_boundary = wkt.dumps(boundary_geom)
+
         landmark = Landmark(
             name=form_param.name,
-            boundary=form_param.boundary,
+            boundary=validated_boundary,
             type=form_param.type,
             alias_names=form_param.alias_names,
         )

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -413,10 +413,9 @@ async def fetch_tokens_operator(
             **Deletes an operator access token.**    
             - Operator must have a valid access token.    
             - Operators can delete their own tokens without additional permissions.    
-            - To delete another operator's token in the same company,    
-              the 'company.operator.token.delete' permission is required,    
-            - Without permission, trying to delete another operator's token or an invalid token ID will result in a `NoPermission` error.    
-            - If the operator has permission and the token ID is invalid or already revoked, the operation is silently ignored.    
+            - To delete another operator's token in the same company, the 'company.operator.token.delete' permission is required.   
+            - Trying to delete another operator's token without permission will result in a `NoPermission` error.   
+            - If the token ID is invalid or already revoked, the operation is silently ignored.    
         """
     ),
 )

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -358,9 +358,8 @@ async def revoke_token(
         """
             **Fetch operator tokens with permission-based filtering.**    
             - If the logged-in operator has `company.operator.token.fetch` permission, all masked tokens are returned.    
-            - If the logged-in operator does not have permission:    
-              - only masked tokens for the logged-in operator are returned.    
-              - Trying to access tokens of other operators will result in `NoPermission` error.    
+            - If the logged-in operator does not have permission, only masked tokens for the logged-in operator are returned.    
+            - Trying to access tokens of other operators without permission will result in `NoPermission` error.    
         """
     ),
 )

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -113,7 +113,7 @@ class OrderBy(StrEnum):
 
 
 class QueryParamsForOP(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFilter):
-    """Query parameters for operator token endpoints (for operator)."""
+    """Query parameters for operator."""
 
     operator_id: int | None = Field(Query(default=None))
     order_by: OrderBy = Field(Query(default=OrderBy.ID, description=enum_str(OrderBy)))
@@ -123,13 +123,13 @@ class QueryParamsForOP(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFi
 
 
 class QueryParamsForEX(QueryParamsForOP):
-    """Query parameters for operator token endpoints (for executive)."""
+    """Query parameters for executive."""
 
     company_id: int | None = Field(Query(default=None))
 
 
 class QueryParams(QueryParamsForEX):
-    """Query parameters for operator token endpoints."""
+    """Query parameters for operator and executive."""
 
     pass
 

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -351,13 +351,16 @@ async def revoke_token(
     responses=fuse_exception_responses(
         [
             exceptions.InvalidToken(),
+            exceptions.NoPermission(),
         ]
     ),
     description=(
         """
-            **Fetch operator tokens with permission-based filtering.**     
+            **Fetch operator tokens with permission-based filtering.**    
             - If the logged-in operator has `company.operator.token.fetch` permission, all masked tokens are returned.    
-            - If the logged-in operator does not have permission, only masked tokens for the logged-in operator are returned.    
+            - If the logged-in operator does not have permission:    
+              - only masked tokens for the logged-in operator are returned.    
+              - Try to access tokens of other operators will result in `NoPermission` error.    
         """
     ),
 )
@@ -377,7 +380,7 @@ async def fetch_tokens_operator(
             query_params.company_id is not None
             and query_params.company_id != token.company_id
         ):
-            return []
+            raise exceptions.NoPermission()
         query_params.company_id = token.company_id
 
         if has_permission is False:
@@ -385,7 +388,7 @@ async def fetch_tokens_operator(
                 query_params.operator_id is not None
                 and query_params.operator_id != token.operator_id
             ):
-                return []
+                raise exceptions.NoPermission()
             query_params.operator_id = token.operator_id
 
         return search_operator_tokens(session, query_params)
@@ -482,12 +485,7 @@ async def fetch_tokens_executive(
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, access_token)
         roles = get_executive_roles(session, token)
-        has_permission = verify_permission(
-            roles, ExecutivePermissionPath.FETCH_COMPANY_OPERATOR_TOKEN, False
-        )
-
-        if has_permission is False:
-            raise exceptions.NoPermission()
+        verify_permission(roles, ExecutivePermissionPath.FETCH_COMPANY_OPERATOR_TOKEN)
 
         return search_operator_tokens(session, query_params)
     except Exception as e:
@@ -530,7 +528,6 @@ async def delete_token_executive(
             .filter(OperatorToken.is_revoked.is_(False))
             .first()
         )
-
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -146,7 +146,7 @@ def search_operator_tokens(
 
     Args:
         session (Session): Active SQLAlchemy database session.
-        query_params (QueryParams): Object containing all possible query parameters for filtering, ordering, and pagination.
+        query_params (QueryParams): Query parameters containing search criteria.
 
     Returns:
         List[OperatorToken]: List of operator tokens that match the search criteria.

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -410,8 +410,9 @@ async def fetch_tokens_operator(
             **Deletes an operator access token.**    
             - Operator must have a valid access token.    
             - Operators can delete their own tokens without additional permissions.    
-            - To delete another operator's token in the same company,  
-              the 'company.operator.token.delete' permission is required.    
+            - To delete another operator's token in the same company,    
+              the 'company.operator.token.delete' permission is required,    
+              otherwise, a `NoPermission` error is returned.    
             - If the token ID is invalid or already revoked, the operation is silently ignored.    
         """
     ),
@@ -428,12 +429,13 @@ async def delete_token_operator(
         token_to_delete = (
             session.query(OperatorToken)
             .filter(OperatorToken.id == id)
-            .filter(OperatorToken.company_id == token.company_id)
             .filter(OperatorToken.is_revoked.is_(False))
             .first()
         )
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
+        if token_to_delete.company_id != token.company_id:
+            raise exceptions.NoPermission()
         if token_to_delete.operator_id != token.operator_id:
             roles = get_operator_roles(session, token)
             verify_permission(

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -360,7 +360,7 @@ async def revoke_token(
             - If the logged-in operator has `company.operator.token.fetch` permission, all masked tokens are returned.    
             - If the logged-in operator does not have permission:    
               - only masked tokens for the logged-in operator are returned.    
-              - Try to access tokens of other operators will result in `NoPermission` error.    
+              - Trying to access tokens of other operators will result in `NoPermission` error.    
         """
     ),
 )

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -383,7 +383,7 @@ async def fetch_tokens_operator(
             raise exceptions.NoPermission()
         query_params.company_id = token.company_id
 
-        if has_permission is False:
+        if not has_permission:
             if (
                 query_params.operator_id is not None
                 and query_params.operator_id != token.operator_id

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -112,20 +112,25 @@ class OrderBy(StrEnum):
     CREATED_ON = "created_on"
 
 
-class QueryParams(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFilter):
+class QueryParamsForOP(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFilter):
     """Query parameters for operator token endpoints."""
 
     operator_id: int | None = Field(Query(default=None))
-    company_id: int | None = Field(Query(default=None))
     order_by: OrderBy = Field(Query(default=OrderBy.ID, description=enum_str(OrderBy)))
     order_in: OrderIn = Field(
         Query(default=OrderIn.DESCENDING, description=enum_str(OrderIn))
     )
 
 
+class QueryParamsForEX(QueryParamsForOP):
+    company_id: int | None = Field(Query(default=None))
+
+
 ## Functions
 def search_operator_tokens(
-    session: Session, query_params: QueryParams
+    session: Session,
+    query_params: QueryParamsForOP | QueryParamsForEX,
+    company_id: int | None = None,
 ) -> List[OperatorToken]:
     """
     Search for operator tokens based on provided query parameters.
@@ -135,17 +140,23 @@ def search_operator_tokens(
 
     Args:
         session (Session): Active SQLAlchemy database session.
-        query_params (QueryParams): Query parameters containing search criteria.
+        query_params (QueryParamsForOP | QueryParamsForEX): Query parameters for filtering, ordering, and pagination.
+        company_id (int | None): Optional company ID for additional filtering (mandatory for QueryParamsForOP).
 
     Returns:
         List[OperatorToken]: List of operator tokens that match the search criteria.
     """
     query = session.query(OperatorToken).filter(OperatorToken.is_revoked == False)
 
+    if (
+        isinstance(query_params, QueryParamsForEX)
+        and query_params.company_id is not None
+    ):
+        query = query.filter(OperatorToken.company_id == query_params.company_id)
+    if isinstance(query_params, QueryParamsForOP):
+        query = query.filter(OperatorToken.company_id == company_id)
     if query_params.operator_id is not None:
         query = query.filter(OperatorToken.operator_id == query_params.operator_id)
-    if query_params.company_id is not None:
-        query = query.filter(OperatorToken.company_id == query_params.company_id)
 
     # generalized helpers
     query = apply_id_filters(query, OperatorToken, query_params)
@@ -364,7 +375,7 @@ async def revoke_token(
     ),
 )
 async def fetch_tokens_operator(
-    query_params: QueryParams = Depends(),
+    query_params: QueryParamsForOP = Depends(),
     access_token=Depends(bearer_operator),
 ):
     try:
@@ -375,22 +386,15 @@ async def fetch_tokens_operator(
             roles, OperatorPermissionPath.FETCH_COMPANY_OPERATOR_TOKEN, False
         )
 
-        if (
-            query_params.company_id is not None
-            and query_params.company_id != token.company_id
-        ):
-            raise exceptions.NoPermission()
-        query_params.company_id = token.company_id
-
         if not has_permission:
-            if (
-                query_params.operator_id is not None
-                and query_params.operator_id != token.operator_id
-            ):
+            if query_params.operator_id not in (None, token.operator_id):
                 raise exceptions.NoPermission()
+            # Restrict to only the logged-in operator's tokens
             query_params.operator_id = token.operator_id
 
-        return search_operator_tokens(session, query_params)
+        return search_operator_tokens(
+            session, query_params, company_id=token.company_id
+        )
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -486,7 +490,7 @@ async def delete_token_operator(
     ),
 )
 async def fetch_tokens_executive(
-    query_params: QueryParams = Depends(),
+    query_params: QueryParamsForEX = Depends(),
     access_token=Depends(oauth2_executive),
 ):
     try:

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -367,9 +367,9 @@ async def revoke_token(
     description=(
         """
             **Fetch operator tokens with permission-based filtering.**    
-            - If the logged-in operator has `company.operator.token.fetch` permission, all masked tokens are returned.    
+            - If the logged-in operator has `company.operator.token.fetch` permission, all masked tokens within the operator's company are returned.    
             - If the logged-in operator does not have permission, only masked tokens for the logged-in operator are returned.    
-            - Trying to access tokens of other operators without permission will result in `NoPermission` error.    
+            - Trying to access tokens of other operators within the same company without permission will result in `NoPermission` error.    
         """
     ),
 )

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -437,19 +437,13 @@ async def delete_token_operator(
         token_to_delete = (
             session.query(OperatorToken)
             .filter(OperatorToken.id == id)
+            .filter(OperatorToken.company_id == token.company_id)
             .filter(OperatorToken.is_revoked.is_(False))
             .first()
         )
-        if not has_permission:
-            if (
-                token_to_delete is None
-                or token_to_delete.company_id != token.company_id
-                or token_to_delete.operator_id != token.operator_id
-            ):
-                raise exceptions.NoPermission()
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
-        if token_to_delete.company_id != token.company_id:
+        if not has_permission and token_to_delete.operator_id != token.operator_id:
             raise exceptions.NoPermission()
 
         token_to_delete.is_revoked = True

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -412,8 +412,8 @@ async def fetch_tokens_operator(
             - Operators can delete their own tokens without additional permissions.    
             - To delete another operator's token in the same company,    
               the 'company.operator.token.delete' permission is required,    
-              otherwise, a `NoPermission` error is returned.    
-            - If the token ID is invalid or already revoked, the operation is silently ignored.    
+            - Without permission, trying to delete another operator's token or an invalid token ID will result in a `NoPermission` error.    
+            - If the operator has permission and the token ID is invalid or already revoked, the operation is silently ignored.    
         """
     ),
 )
@@ -425,6 +425,12 @@ async def delete_token_operator(
     try:
         session = SessionLocal()
         token = verify_token(session, OperatorToken, access_token.credentials)
+        roles = get_operator_roles(session, token)
+        has_permission = verify_permission(
+            roles,
+            OperatorPermissionPath.DELETE_COMPANY_OPERATOR_TOKEN,
+            False,
+        )
 
         token_to_delete = (
             session.query(OperatorToken)
@@ -432,17 +438,18 @@ async def delete_token_operator(
             .filter(OperatorToken.is_revoked.is_(False))
             .first()
         )
+        if not has_permission:
+            if (
+                token_to_delete is None
+                or token_to_delete.company_id != token.company_id
+                or token_to_delete.operator_id != token.operator_id
+            ):
+                raise exceptions.NoPermission()
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
         if token_to_delete.company_id != token.company_id:
             raise exceptions.NoPermission()
-        if token_to_delete.operator_id != token.operator_id:
-            roles = get_operator_roles(session, token)
-            verify_permission(
-                roles, OperatorPermissionPath.DELETE_COMPANY_OPERATOR_TOKEN
-            )
 
-        # Revoke token
         token_to_delete.is_revoked = True
         session.commit()
         session.refresh(token_to_delete)

--- a/app/api/operator_token.py
+++ b/app/api/operator_token.py
@@ -113,7 +113,7 @@ class OrderBy(StrEnum):
 
 
 class QueryParamsForOP(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFilter):
-    """Query parameters for operator token endpoints."""
+    """Query parameters for operator token endpoints (for operator)."""
 
     operator_id: int | None = Field(Query(default=None))
     order_by: OrderBy = Field(Query(default=OrderBy.ID, description=enum_str(OrderBy)))
@@ -123,14 +123,20 @@ class QueryParamsForOP(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFi
 
 
 class QueryParamsForEX(QueryParamsForOP):
+    """Query parameters for operator token endpoints (for executive)."""
+
     company_id: int | None = Field(Query(default=None))
+
+
+class QueryParams(QueryParamsForEX):
+    """Query parameters for operator token endpoints."""
+
+    pass
 
 
 ## Functions
 def search_operator_tokens(
-    session: Session,
-    query_params: QueryParamsForOP | QueryParamsForEX,
-    company_id: int | None = None,
+    session: Session, query_params: QueryParams
 ) -> List[OperatorToken]:
     """
     Search for operator tokens based on provided query parameters.
@@ -140,21 +146,14 @@ def search_operator_tokens(
 
     Args:
         session (Session): Active SQLAlchemy database session.
-        query_params (QueryParamsForOP | QueryParamsForEX): Query parameters for filtering, ordering, and pagination.
-        company_id (int | None): Optional company ID for additional filtering (mandatory for QueryParamsForOP).
+        query_params (QueryParams): Object containing all possible query parameters for filtering, ordering, and pagination.
 
     Returns:
         List[OperatorToken]: List of operator tokens that match the search criteria.
     """
     query = session.query(OperatorToken).filter(OperatorToken.is_revoked == False)
-
-    if (
-        isinstance(query_params, QueryParamsForEX)
-        and query_params.company_id is not None
-    ):
+    if query_params.company_id is not None:
         query = query.filter(OperatorToken.company_id == query_params.company_id)
-    if isinstance(query_params, QueryParamsForOP):
-        query = query.filter(OperatorToken.company_id == company_id)
     if query_params.operator_id is not None:
         query = query.filter(OperatorToken.operator_id == query_params.operator_id)
 
@@ -393,7 +392,8 @@ async def fetch_tokens_operator(
             query_params.operator_id = token.operator_id
 
         return search_operator_tokens(
-            session, query_params, company_id=token.company_id
+            session,
+            QueryParams(**query_params.model_dump(), company_id=token.company_id),
         )
     except Exception as e:
         exceptions.handle(e)
@@ -499,7 +499,7 @@ async def fetch_tokens_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.FETCH_COMPANY_OPERATOR_TOKEN)
 
-        return search_operator_tokens(session, query_params)
+        return search_operator_tokens(session, QueryParams(**query_params.model_dump()))
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -116,7 +116,7 @@ class OrderBy(StrEnum):
 
 
 class QueryParamsForVE(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFilter):
-    """Query parameters for vendor token endpoints (for vendor)."""
+    """Query parameters for vendor."""
 
     vendor_id: int | None = Field(Query(default=None))
     order_by: OrderBy = Field(Query(default=OrderBy.ID, description=enum_str(OrderBy)))
@@ -126,13 +126,13 @@ class QueryParamsForVE(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFi
 
 
 class QueryParamsForEX(QueryParamsForVE):
-    """Query parameters for vendor token endpoints (for executive)."""
+    """Query parameters for executive."""
 
     business_id: int | None = Field(Query(default=None))
 
 
 class QueryParams(QueryParamsForEX):
-    """Query parameters for vendor token endpoints."""
+    """Query parameters for vendor and executive."""
 
     pass
 

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -410,8 +410,9 @@ async def fetch_tokens_vendor(
             **Deletes a vendor access token.**    
             - Vendor must have a valid access token.    
             - Vendors can delete their own tokens without additional permissions.    
-            - To delete another vendor's token in the same business,  
-              the 'business.vendor.token.delete' permission is required.    
+            - To delete another vendor's token in the same business,    
+              the 'business.vendor.token.delete' permission is required,    
+              otherwise a `NoPermission` error is raised.    
             - If the token ID is invalid or already revoked, the operation is silently ignored.    
         """
     ),
@@ -428,12 +429,13 @@ async def delete_token_vendor(
         token_to_delete = (
             session.query(VendorToken)
             .filter(VendorToken.id == id)
-            .filter(VendorToken.business_id == token.business_id)
             .filter(VendorToken.is_revoked.is_(False))
             .first()
         )
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
+        if token_to_delete.business_id != token.business_id:
+            raise exceptions.NoPermission()
         if token_to_delete.vendor_id != token.vendor_id:
             roles = get_vendor_roles(session, token)
             verify_permission(roles, VendorPermissionPath.DELETE_BUSINESS_VENDOR_TOKEN)

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -412,8 +412,8 @@ async def fetch_tokens_vendor(
             - Vendors can delete their own tokens without additional permissions.    
             - To delete another vendor's token in the same business,    
               the 'business.vendor.token.delete' permission is required,    
-              otherwise a `NoPermission` error is raised.    
-            - If the token ID is invalid or already revoked, the operation is silently ignored.    
+            - without permission, trying to delete another vendor's token or an invalid token ID will result in a `NoPermission` error.    
+            - If the vendor has permission and the token ID is invalid or already revoked, the operation is silently ignored.    
         """
     ),
 )
@@ -425,6 +425,10 @@ async def delete_token_vendor(
     try:
         session = SessionLocal()
         token = verify_token(session, VendorToken, access_token.credentials)
+        roles = get_vendor_roles(session, token)
+        has_permission = verify_permission(
+            roles, VendorPermissionPath.DELETE_BUSINESS_VENDOR_TOKEN, False
+        )
 
         token_to_delete = (
             session.query(VendorToken)
@@ -432,13 +436,17 @@ async def delete_token_vendor(
             .filter(VendorToken.is_revoked.is_(False))
             .first()
         )
+        if not has_permission:
+            if (
+                token_to_delete is None
+                or token_to_delete.vendor_id != token.vendor_id
+                or token_to_delete.business_id != token.business_id
+            ):
+                raise exceptions.NoPermission()
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
         if token_to_delete.business_id != token.business_id:
             raise exceptions.NoPermission()
-        if token_to_delete.vendor_id != token.vendor_id:
-            roles = get_vendor_roles(session, token)
-            verify_permission(roles, VendorPermissionPath.DELETE_BUSINESS_VENDOR_TOKEN)
 
         # Revoke token
         token_to_delete.is_revoked = True

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -383,7 +383,7 @@ async def fetch_tokens_vendor(
             raise exceptions.NoPermission()
         query_params.business_id = token.business_id
 
-        if has_permission is False:
+        if not has_permission:
             if (
                 query_params.vendor_id is not None
                 and query_params.vendor_id != token.vendor_id

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -360,7 +360,7 @@ async def revoke_token(
             - If the logged-in vendor has `company.vendor.token.fetch` permission, all masked tokens are returned.    
             - If the logged-in vendor does not have permission:    
               - only masked tokens for the logged-in vendor are returned.    
-              - Try to access tokens of other vendors will result in `NoPermission` error.    
+              - Trying to access tokens of other vendors will result in `NoPermission` error.    
         """
     ),
 )

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -144,7 +144,6 @@ def search_vendor_tokens(
         List[VendorToken]: List of vendor tokens that match the search criteria.
     """
     query = session.query(VendorToken).filter(VendorToken.is_revoked == False)
-
     if query_params.vendor_id is not None:
         query = query.filter(VendorToken.vendor_id == query_params.vendor_id)
     if query_params.business_id is not None:

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -115,15 +115,26 @@ class OrderBy(StrEnum):
     CREATED_ON = "created_on"
 
 
-class QueryParams(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFilter):
-    """Query parameters for vendor token endpoints."""
+class QueryParamsForVE(ClientDataFilter, CreatedOnFilter, IDFilter, PaginationFilter):
+    """Query parameters for vendor token endpoints (for vendor)."""
 
     vendor_id: int | None = Field(Query(default=None))
-    business_id: int | None = Field(Query(default=None))
     order_by: OrderBy = Field(Query(default=OrderBy.ID, description=enum_str(OrderBy)))
     order_in: OrderIn = Field(
         Query(default=OrderIn.DESCENDING, description=enum_str(OrderIn))
     )
+
+
+class QueryParamsForEX(QueryParamsForVE):
+    """Query parameters for vendor token endpoints (for executive)."""
+
+    business_id: int | None = Field(Query(default=None))
+
+
+class QueryParams(QueryParamsForEX):
+    """Query parameters for vendor token endpoints."""
+
+    pass
 
 
 ## Functions
@@ -144,10 +155,10 @@ def search_vendor_tokens(
         List[VendorToken]: List of vendor tokens that match the search criteria.
     """
     query = session.query(VendorToken).filter(VendorToken.is_revoked == False)
-    if query_params.vendor_id is not None:
-        query = query.filter(VendorToken.vendor_id == query_params.vendor_id)
     if query_params.business_id is not None:
         query = query.filter(VendorToken.business_id == query_params.business_id)
+    if query_params.vendor_id is not None:
+        query = query.filter(VendorToken.vendor_id == query_params.vendor_id)
 
     # generalized helpers
     query = apply_id_filters(query, VendorToken, query_params)
@@ -356,15 +367,14 @@ async def revoke_token(
     description=(
         """
             **Fetch vendor tokens with permission-based filtering.**    
-            - If the logged-in vendor has `company.vendor.token.fetch` permission, all masked tokens are returned.    
-            - If the logged-in vendor does not have permission:    
-              - only masked tokens for the logged-in vendor are returned.    
-              - Trying to access tokens of other vendors will result in `NoPermission` error.    
+            - If the logged-in vendor has `business.vendor.token.fetch` permission, all masked tokens are returned.    
+            - If the logged-in vendor does not have permission, only masked tokens for the logged-in vendor are returned.   
+            - Trying to access tokens of other vendors without permission will result in `NoPermission` error.     
         """
     ),
 )
 async def fetch_tokens_vendor(
-    query_params: QueryParams = Depends(),
+    query_params: QueryParamsForVE = Depends(),
     access_token=Depends(bearer_vendor),
 ):
     try:
@@ -375,22 +385,16 @@ async def fetch_tokens_vendor(
             roles, VendorPermissionPath.FETCH_BUSINESS_VENDOR_TOKEN, False
         )
 
-        if (
-            query_params.business_id is not None
-            and query_params.business_id != token.business_id
-        ):
-            raise exceptions.NoPermission()
-        query_params.business_id = token.business_id
-
         if not has_permission:
-            if (
-                query_params.vendor_id is not None
-                and query_params.vendor_id != token.vendor_id
-            ):
+            if query_params.vendor_id not in (None, token.vendor_id):
                 raise exceptions.NoPermission()
+            # Restrict to only the logged-in vendor's tokens
             query_params.vendor_id = token.vendor_id
 
-        return search_vendor_tokens(session, query_params)
+        return search_vendor_tokens(
+            session,
+            QueryParams(**query_params.model_dump(), business_id=token.business_id),
+        )
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -485,7 +489,7 @@ async def delete_token_vendor(
     ),
 )
 async def fetch_tokens_executive(
-    query_params: QueryParams = Depends(),
+    query_params: QueryParamsForEX = Depends(),
     access_token=Depends(oauth2_executive),
 ):
     try:

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -413,10 +413,9 @@ async def fetch_tokens_vendor(
             **Deletes a vendor access token.**    
             - Vendor must have a valid access token.    
             - Vendors can delete their own tokens without additional permissions.    
-            - To delete another vendor's token in the same business,    
-              the 'business.vendor.token.delete' permission is required,    
-            - without permission, trying to delete another vendor's token or an invalid token ID will result in a `NoPermission` error.    
-            - If the vendor has permission and the token ID is invalid or already revoked, the operation is silently ignored.    
+            - To delete another vendor's token in the same business, the 'business.vendor.token.delete' permission is required,    
+            - Trying to delete another vendor's token without permission will result in a `NoPermission` error.   
+            - If the token ID is invalid or already revoked, the operation is silently ignored.   
         """
     ),
 )
@@ -436,22 +435,15 @@ async def delete_token_vendor(
         token_to_delete = (
             session.query(VendorToken)
             .filter(VendorToken.id == id)
+            .filter(VendorToken.business_id == token.business_id)
             .filter(VendorToken.is_revoked.is_(False))
             .first()
         )
-        if not has_permission:
-            if (
-                token_to_delete is None
-                or token_to_delete.vendor_id != token.vendor_id
-                or token_to_delete.business_id != token.business_id
-            ):
-                raise exceptions.NoPermission()
         if token_to_delete is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
-        if token_to_delete.business_id != token.business_id:
+        if not has_permission and token_to_delete.vendor_id != token.vendor_id:
             raise exceptions.NoPermission()
 
-        # Revoke token
         token_to_delete.is_revoked = True
         session.commit()
         session.refresh(token_to_delete)

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -348,13 +348,16 @@ async def revoke_token(
     URL_VENDOR_TOKEN,
     tags=["Token"],
     response_model=list[MaskedVendorTokenSchema],
-    responses=fuse_exception_responses([exceptions.InvalidToken()]),
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
     description=(
         """
-            **Fetch vendor tokens with optional filtering.**     
-            - Retrieve masked vendor tokens (without revealing the actual tokens).     
-            - Filter by vendor ID, creation date, or other query parameters.     
-            - Results are paginated and can be ordered by ID or creation date.     
+            **Fetch vendor tokens with permission-based filtering.**    
+            - If the logged-in vendor has `company.vendor.token.fetch` permission, all masked tokens are returned.    
+            - If the logged-in vendor does not have permission:    
+              - only masked tokens for the logged-in vendor are returned.    
+              - Try to access tokens of other vendors will result in `NoPermission` error.    
         """
     ),
 )
@@ -374,7 +377,7 @@ async def fetch_tokens_vendor(
             query_params.business_id is not None
             and query_params.business_id != token.business_id
         ):
-            return []
+            raise exceptions.NoPermission()
         query_params.business_id = token.business_id
 
         if has_permission is False:
@@ -382,7 +385,7 @@ async def fetch_tokens_vendor(
                 query_params.vendor_id is not None
                 and query_params.vendor_id != token.vendor_id
             ):
-                return []
+                raise exceptions.NoPermission()
             query_params.vendor_id = token.vendor_id
 
         return search_vendor_tokens(session, query_params)
@@ -421,12 +424,7 @@ async def fetch_tokens_executive(
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, access_token)
         roles = get_executive_roles(session, token)
-        has_permission = verify_permission(
-            roles, ExecutivePermissionPath.FETCH_BUSINESS_VENDOR_TOKEN, False
-        )
-
-        if has_permission is False:
-            raise exceptions.NoPermission()
+        verify_permission(roles, ExecutivePermissionPath.FETCH_BUSINESS_VENDOR_TOKEN)
 
         return search_vendor_tokens(session, query_params)
     except Exception as e:

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -413,7 +413,7 @@ async def fetch_tokens_vendor(
             **Deletes a vendor access token.**    
             - Vendor must have a valid access token.    
             - Vendors can delete their own tokens without additional permissions.    
-            - To delete another vendor's token in the same business, the 'business.vendor.token.delete' permission is required,    
+            - To delete another vendor's token in the same business, the 'business.vendor.token.delete' permission is required.    
             - Trying to delete another vendor's token without permission will result in a `NoPermission` error.   
             - If the token ID is invalid or already revoked, the operation is silently ignored.   
         """

--- a/app/api/vendor_token.py
+++ b/app/api/vendor_token.py
@@ -367,9 +367,9 @@ async def revoke_token(
     description=(
         """
             **Fetch vendor tokens with permission-based filtering.**    
-            - If the logged-in vendor has `business.vendor.token.fetch` permission, all masked tokens are returned.    
+            - If the logged-in vendor has `business.vendor.token.fetch` permission, all masked tokens within the vendor's business are returned.    
             - If the logged-in vendor does not have permission, only masked tokens for the logged-in vendor are returned.   
-            - Trying to access tokens of other vendors without permission will result in `NoPermission` error.     
+            - Trying to access tokens of other vendors within the same business without permission will result in `NoPermission` error.     
         """
     ),
 )


### PR DESCRIPTION


### **Summary of Changes**
- Updated token fetch endpoints for Executive, Operator, and Vendor to enforce consistent permission-based filtering behavior.
- Also updated the delete token endpoints to properly enforce permission checks and return 403 (NoPermission) when attempting to delete another user’s token without the required permission.

### **How to Test / Verify**
- Verify token fetch behavior with and without permission.
- Ensure 403 is returned when accessing another user’s tokens without permission.
- Confirm only own tokens are returned when permission is missing.
- Users can delete their own tokens.
- Attempting to delete another user’s token without permission returns 403.
- Attempting to delete a token from another company/business returns 204.
- Invalid or already revoked token IDs return 204 No Content.



### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
