### PR TITLE
Create patch endpoint for operator account in executive and operator app

### DIFF
--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -341,7 +341,6 @@ async def update_account_operator(
         )
         if operator is None:
             raise exceptions.UnknownValue(Operator.id)
-
         if is_self_update and form_param.status is not None:
             raise exceptions.NoPermission()
 

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -1,9 +1,9 @@
 """
 Operator Account API Router for EnteBus.
 
-Provides endpoints for managing operator accounts, including creation, update.
+Provides endpoints for managing operator accounts, including creation and update.
 Uses Pydantic schemas for input validation and structured output.
-Endpoints for deletion, and retrieval are planned for future implementation.
+Endpoints for deletion and retrieval are planned for future implementation.
 """
 
 from datetime import datetime
@@ -320,15 +320,20 @@ async def update_account_operator(
         session = SessionLocal()
         token = verify_token(session, OperatorToken, access_token.credentials)
 
-        operator = session.query(Operator).filter(Operator.id == id).first()
+        is_self_update = id == token.operator_id
+        if not is_self_update:
+            roles = get_operator_roles(session, token)
+            verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_OPERATOR)
+
+        operator = (
+            session.query(Operator)
+            .filter(Operator.id == id, Operator.company_id == token.company_id)
+            .first()
+        )
         if operator is None:
             raise exceptions.UnknownValue(Operator.id)
 
         update_data = form_param.model_dump(exclude_unset=True)
-        is_self_update = operator.id == token.operator_id
-        if not is_self_update:
-            roles = get_operator_roles(session, token)
-            verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_OPERATOR)
         if is_self_update and Operator.status.key in update_data:
             raise exceptions.NoPermission()
 

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -6,11 +6,13 @@ Uses Pydantic schemas for input validation and structured output.
 Endpoints for deletion and retrieval are planned for future implementation.
 """
 
+from typing import Tuple
 from datetime import datetime
 from fastapi import APIRouter, status, Depends
 from fastapi.encoders import jsonable_encoder
 from pydantic_extra_types.phone_numbers import PhoneNumber
 from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy.orm.session import Session
 
 from app.api.bearer import oauth2_executive, bearer_operator
 from app.src.db import ExecutiveToken, OperatorToken, SessionLocal, Operator
@@ -108,6 +110,34 @@ class UpdateForm(BaseModel):
     )
 
 
+## Functions
+def update_operator(
+    session: Session, operator: Operator, form_param: UpdateForm
+) -> Tuple[bool, dict]:
+
+    update_data = form_param.model_dump(exclude_unset=True)
+    tokens_revoked = False
+    if form_param.status == AccountStatus.SUSPENDED:
+        tokens_revoked = (
+            session.query(OperatorToken)
+            .filter(
+                OperatorToken.operator_id == operator.id,
+                OperatorToken.is_revoked.is_(False),
+            )
+            .update({OperatorToken.is_revoked: True})
+            > 0
+        )
+
+    update_if_changed(operator, update_data)
+    have_updates = session.is_modified(operator) or tokens_revoked
+    if have_updates:
+        session.commit()
+        session.refresh(operator)
+
+    operator_data = jsonable_encoder(operator, exclude={Operator.password.name})
+    return have_updates, operator_data
+
+
 # ---------------------------------------------------------------------------
 ## API endpoints [Executive]
 # ---------------------------------------------------------------------------
@@ -201,28 +231,7 @@ async def update_account_executive(
         if operator is None:
             raise exceptions.UnknownValue(Operator.id)
 
-        update_data = form_param.model_dump(exclude_unset=True)
-
-        # Revoking all the tokens for a suspended operator
-        tokens_revoked = False
-        if form_param.status == AccountStatus.SUSPENDED:
-            tokens_revoked = (
-                session.query(OperatorToken)
-                .filter(
-                    OperatorToken.operator_id == id,
-                    OperatorToken.is_revoked.is_(False),
-                )
-                .update({OperatorToken.is_revoked: True})
-                > 0
-            )
-
-        update_if_changed(operator, update_data)
-        have_updates = session.is_modified(operator) or tokens_revoked
-        if have_updates:
-            session.commit()
-            session.refresh(operator)
-
-        operator_data = jsonable_encoder(operator, exclude={Operator.password.name})
+        have_updates, operator_data = update_operator(session, operator, form_param)
         if have_updates:
             log_event(token, request_info, operator_data)
         return operator_data
@@ -333,30 +342,10 @@ async def update_account_operator(
         if operator is None:
             raise exceptions.UnknownValue(Operator.id)
 
-        update_data = form_param.model_dump(exclude_unset=True)
-        if is_self_update and Operator.status.key in update_data:
+        if is_self_update and form_param.status is not None:
             raise exceptions.NoPermission()
 
-        # Revoking all the tokens for a suspended operator
-        tokens_revoked = False
-        if form_param.status == AccountStatus.SUSPENDED:
-            tokens_revoked = (
-                session.query(OperatorToken)
-                .filter(
-                    OperatorToken.operator_id == id,
-                    OperatorToken.is_revoked.is_(False),
-                )
-                .update({OperatorToken.is_revoked: True})
-                > 0
-            )
-
-        update_if_changed(operator, update_data)
-        have_updates = session.is_modified(operator) or tokens_revoked
-        if have_updates:
-            session.commit()
-            session.refresh(operator)
-
-        operator_data = jsonable_encoder(operator, exclude={Operator.password.name})
+        have_updates, operator_data = update_operator(session, operator, form_param)
         if have_updates:
             log_event(token, request_info, operator_data)
         return operator_data

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -28,6 +28,7 @@ from app.src.functions import (
     get_executive_roles,
     get_operator_roles,
     get_request_info,
+    update_if_changed,
 )
 
 
@@ -85,6 +86,30 @@ class CreateFormForEX(CreateFormForOP):
     company_id: int = Field()
 
 
+class UpdateForm(BaseModel):
+    """Form data for updating an operator account."""
+
+    password: str = Field(min_length=8, max_length=32, pattern=PASSWORD_PATTERN)
+    gender: GenderType = Field(
+        description=enum_str(GenderType), default=GenderType.OTHER
+    )
+    description: str | None = Field(min_length=1, max_length=32, default=None)
+    type: OperatorType = Field(
+        description=enum_str(OperatorType),
+        default=OperatorType.NORMAL,
+    )
+    full_name: str | None = Field(min_length=1, max_length=32, default=None)
+    status: AccountStatus = Field(
+        description=enum_str(AccountStatus), default=AccountStatus.ACTIVE
+    )
+    phone_number: PhoneNumber | None = Field(
+        max_length=32, default=None, description="Phone number in RFC 3966 format"
+    )
+    email_id: EmailStr | None = Field(
+        max_length=256, default=None, description="Email in RFC 5322 format"
+    )
+
+
 # ---------------------------------------------------------------------------
 ## API endpoints [Executive]
 # ---------------------------------------------------------------------------
@@ -135,6 +160,71 @@ async def create_account_executive(
 
         operator_data = jsonable_encoder(operator, exclude={Operator.password.name})
         log_event(token, request_info, operator_data)
+        return operator_data
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_executive.patch(
+    f"{URL_OPERATOR_ACCOUNT}/{{id}}",
+    tags=["Operator Account"],
+    response_model=OperatorSchema,
+    responses=fuse_exception_responses(
+        [
+            exceptions.InvalidToken(),
+            exceptions.NoPermission(),
+            exceptions.UnknownValue(Operator.id),
+        ]
+    ),
+    description=(
+        """
+            **Updates an existing operator account.**    
+            - Requires a valid access token.    
+            - Logged-in executive must have `company.operator.update` permission to update other operators.    
+            - Empty PATCH requests are allowed and will result in no changes.    
+        """
+    ),
+)
+async def update_account(
+    id: int,
+    form_param: UpdateForm,
+    access_token=Depends(oauth2_executive),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, ExecutiveToken, access_token)
+
+        operator = session.query(Operator).filter(Operator.id == id).first()
+        if operator is None:
+            raise exceptions.UnknownValue(Operator.id)
+
+        update_data = form_param.model_dump(exclude_unset=True)
+
+        # Revoking all the tokens for a suspended operator
+        tokens_revoked = False
+        if form_param.status == AccountStatus.SUSPENDED:
+            tokens_revoked = (
+                session.query(OperatorToken)
+                .filter(
+                    OperatorToken.operator_id == id,
+                    OperatorToken.is_revoked.is_(False),
+                )
+                .update({OperatorToken.is_revoked: True})
+                > 0
+            )
+
+        update_if_changed(operator, update_data)
+        have_updates = session.is_modified(operator) or tokens_revoked
+        if have_updates:
+            session.commit()
+            session.refresh(operator)
+
+        operator_data = jsonable_encoder(operator, exclude={Operator.password.name})
+        if have_updates:
+            log_event(token, request_info, operator_data)
         return operator_data
     except Exception as e:
         exceptions.handle(e)

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -1,9 +1,9 @@
 """
 Operator Account API Router for EnteBus.
 
-Provides endpoints for managing operator accounts, including creation.
+Provides endpoints for managing operator accounts, including creation, update.
 Uses Pydantic schemas for input validation and structured output.
-Endpoints for update, deletion, and retrieval are planned for future implementation.
+Endpoints for deletion, and retrieval are planned for future implementation.
 """
 
 from datetime import datetime
@@ -89,19 +89,17 @@ class CreateFormForEX(CreateFormForOP):
 class UpdateForm(BaseModel):
     """Form data for updating an operator account."""
 
-    password: str = Field(min_length=8, max_length=32, pattern=PASSWORD_PATTERN)
-    gender: GenderType = Field(
-        description=enum_str(GenderType), default=GenderType.OTHER
+    password: str = Field(
+        default=None, min_length=8, max_length=32, pattern=PASSWORD_PATTERN
     )
+    gender: GenderType = Field(description=enum_str(GenderType), default=None)
     description: str | None = Field(min_length=1, max_length=32, default=None)
     type: OperatorType = Field(
         description=enum_str(OperatorType),
-        default=OperatorType.NORMAL,
+        default=None,
     )
     full_name: str | None = Field(min_length=1, max_length=32, default=None)
-    status: AccountStatus = Field(
-        description=enum_str(AccountStatus), default=AccountStatus.ACTIVE
-    )
+    status: AccountStatus = Field(description=enum_str(AccountStatus), default=None)
     phone_number: PhoneNumber | None = Field(
         max_length=32, default=None, description="Phone number in RFC 3966 format"
     )
@@ -187,7 +185,7 @@ async def create_account_executive(
         """
     ),
 )
-async def update_account(
+async def update_account_executive(
     id: int,
     form_param: UpdateForm,
     access_token=Depends(oauth2_executive),
@@ -196,6 +194,8 @@ async def update_account(
     try:
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, access_token)
+        roles = get_executive_roles(session, token)
+        verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR)
 
         operator = session.query(Operator).filter(Operator.id == id).first()
         if operator is None:
@@ -282,6 +282,78 @@ async def create_account_operator(
 
         operator_data = jsonable_encoder(operator, exclude={Operator.password.name})
         log_event(token, request_info, operator_data)
+        return operator_data
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_operator.patch(
+    f"{URL_OPERATOR_ACCOUNT}/{{id}}",
+    tags=["Operator Account"],
+    response_model=OperatorSchema,
+    responses=fuse_exception_responses(
+        [
+            exceptions.InvalidToken(),
+            exceptions.NoPermission(),
+            exceptions.UnknownValue(Operator.id),
+        ]
+    ),
+    description=(
+        """
+            **Updates an existing operator account.**    
+            - Requires a valid access token.    
+            - Logged-in operator must have `company.operator.update` permission to update other operators.    
+            - Operator can update their own account except status.    
+            - Empty PATCH requests are allowed and will result in no changes.    
+        """
+    ),
+)
+async def update_account_operator(
+    id: int,
+    form_param: UpdateForm,
+    access_token=Depends(bearer_operator),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, OperatorToken, access_token.credentials)
+
+        operator = session.query(Operator).filter(Operator.id == id).first()
+        if operator is None:
+            raise exceptions.UnknownValue(Operator.id)
+
+        update_data = form_param.model_dump(exclude_unset=True)
+        is_self_update = operator.id == token.operator_id
+        if not is_self_update:
+            roles = get_operator_roles(session, token)
+            verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_OPERATOR)
+        if is_self_update and Operator.status.key in update_data:
+            raise exceptions.NoPermission()
+
+        # Revoking all the tokens for a suspended operator
+        tokens_revoked = False
+        if form_param.status == AccountStatus.SUSPENDED:
+            tokens_revoked = (
+                session.query(OperatorToken)
+                .filter(
+                    OperatorToken.operator_id == id,
+                    OperatorToken.is_revoked.is_(False),
+                )
+                .update({OperatorToken.is_revoked: True})
+                > 0
+            )
+
+        update_if_changed(operator, update_data)
+        have_updates = session.is_modified(operator) or tokens_revoked
+        if have_updates:
+            session.commit()
+            session.refresh(operator)
+
+        operator_data = jsonable_encoder(operator, exclude={Operator.password.name})
+        if have_updates:
+            log_event(token, request_info, operator_data)
         return operator_data
     except Exception as e:
         exceptions.handle(e)


### PR DESCRIPTION
### **Summary of Changes**
- Added a PATCH endpoint for updating operator accounts in both the Executive and Operator apps.
- Validated the token before execution.
- Checked the permission before allowing the update.
- Revokes operator tokens when the operator status is updated to suspended.
- The endpoint is properly documented.

### **How to Test / Verify**
- Make sure the operator account update is working as expected.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A

### **Reviewer Notes**
N/A
