### PR TITLE
Create delete endpoints for operator role map in executive and operat…

### DIFF
--- a/app/api/operator_role_map.py
+++ b/app/api/operator_role_map.py
@@ -7,7 +7,7 @@ Endpoints for deletion are planned for future implementation.
 """
 
 from datetime import datetime
-from fastapi import APIRouter, status, Depends, Query
+from fastapi import APIRouter, Response, status, Depends, Query
 from enum import StrEnum
 from typing import List
 from fastapi.encoders import jsonable_encoder
@@ -146,6 +146,23 @@ def search_role_map(
 
     role_maps = query.all()
     return role_maps
+
+
+def delete_role_map(session: Session, role_map: OperatorRoleMap) -> dict:
+    """
+    Deletes an OperatorRoleMap from the database.
+
+    Args:
+        session (Session): SQLAlchemy database session.
+        role_map (OperatorRoleMap): OperatorRoleMap to delete.
+
+    Returns:
+        dict: JSON-encoded representation of the deleted role mapping.
+    """
+    role_map_data = jsonable_encoder(role_map)
+    session.delete(role_map)
+    session.commit()
+    return role_map_data
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +306,44 @@ async def update_role_map_executive(
         if have_updates:
             log_event(token, request_info, role_map_data)
         return role_map_data
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_executive.delete(
+    f"{URL_OPERATOR_ROLE_MAP}/{{id}}",
+    tags=["Operator Role Map"],
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
+    description=(
+        """
+            **Deletes an existing operator role mapping.**    
+            - Requires a valid access token for authentication.    
+            - The logged-in executive must have the `company.operator.role.map.delete` permission.    
+            - Returns 204 No Content even if the specified role mapping does not exist.    
+        """
+    ),
+)
+async def delete_role_map_executive(
+    id: int,
+    access_token=Depends(oauth2_executive),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, ExecutiveToken, access_token)
+        roles = get_executive_roles(session, token)
+        verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR_ROLE)
+
+        role = session.query(OperatorRoleMap).filter(OperatorRoleMap.id == id).first()
+        if role is not None:
+            role_map_data = delete_role_map(session, role)
+            log_event(token, request_info, role_map_data)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -464,6 +519,48 @@ async def update_role_map_operator(
         if have_updates:
             log_event(token, request_info, role_map_data)
         return role_map_data
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_operator.delete(
+    f"{URL_OPERATOR_ROLE_MAP}/{{id}}",
+    tags=["Role Map"],
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
+    description=(
+        """
+            **Deletes an existing operator role mapping.**    
+            - Requires a valid access token for authentication.    
+            - The logged-in operator must have the `company.operator.role_map.delete` permission.    
+            - Returns 204 No Content even if the specified role mapping does not exist.    
+        """
+    ),
+)
+async def delete_role_map_operator(
+    id: int,
+    access_token=Depends(bearer_operator),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, OperatorToken, access_token.credentials)
+        roles = get_operator_roles(session, token)
+        verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_OPERATOR_ROLE)
+
+        role_map = (
+            session.query(OperatorRoleMap)
+            .filter(OperatorRoleMap.id == id, OperatorRoleMap.company_id == token.company_id)
+            .first()
+        )
+        if role_map is not None:
+            role_map_data = delete_role_map(session, role_map)
+            log_event(token, request_info, role_map_data)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/operator_role_map.py
+++ b/app/api/operator_role_map.py
@@ -554,7 +554,9 @@ async def delete_role_map_operator(
 
         role_map = (
             session.query(OperatorRoleMap)
-            .filter(OperatorRoleMap.id == id, OperatorRoleMap.company_id == token.company_id)
+            .filter(
+                OperatorRoleMap.id == id, OperatorRoleMap.company_id == token.company_id
+            )
             .first()
         )
         if role_map is not None:

--- a/app/api/operator_role_map.py
+++ b/app/api/operator_role_map.py
@@ -1,9 +1,9 @@
 """
 Operator Role Map API Router for EnteBus.
 
-Provides endpoints for managing operator role mappings, including creation, update, and retrieval.
-Uses Pydantic schemas for input validation and structured output.
-Endpoints for deletion are planned for future implementation.
+Provides endpoints for managing operator role mappings, including creation,
+update, deletion, and retrieval. Uses Pydantic schemas for
+input validation and structured output.
 """
 
 from datetime import datetime
@@ -323,7 +323,7 @@ async def update_role_map_executive(
         """
             **Deletes an existing operator role mapping.**    
             - Requires a valid access token for authentication.    
-            - The logged-in executive must have the `company.operator.role.map.delete` permission.    
+            - The logged-in executive must have the `company.operator.role.update` permission.    
             - Returns 204 No Content even if the specified role mapping does not exist.    
         """
     ),
@@ -339,9 +339,11 @@ async def delete_role_map_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR_ROLE)
 
-        role = session.query(OperatorRoleMap).filter(OperatorRoleMap.id == id).first()
-        if role is not None:
-            role_map_data = delete_role_map(session, role)
+        role_map = (
+            session.query(OperatorRoleMap).filter(OperatorRoleMap.id == id).first()
+        )
+        if role_map is not None:
+            role_map_data = delete_role_map(session, role_map)
             log_event(token, request_info, role_map_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
@@ -536,7 +538,7 @@ async def update_role_map_operator(
         """
             **Deletes an existing operator role mapping.**    
             - Requires a valid access token for authentication.    
-            - The logged-in operator must have the `company.operator.role_map.delete` permission.    
+            - The logged-in operator must have the `company.operator.role.update` permission.    
             - Returns 204 No Content even if the specified role mapping does not exist.    
         """
     ),


### PR DESCRIPTION


### **Summary of Changes**
- Added a DELETE endpoint for deleting operator role  map in both the Executive and Operator apps.
- Validated the token before execution.
- Checked the permission before allowing the delete. 

### **How to Test / Verify**
- Make sure the operator role map deletion works as expected.
- Verify that users without permission cannot delete a role map.
- Verify that users with the required permission can delete a role map.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A