### PR TITLE
Create post and delete endpoints for operator image in executive and operator app

### DIFF
--- a/app/api/controller.py
+++ b/app/api/controller.py
@@ -18,6 +18,7 @@ from app.api import (
     executive_role,
     landmark,
     operator_account,
+    operator_image,
     operator_role,
     operator_role_map,
     operator_token,
@@ -57,6 +58,7 @@ app_executive.include_router(vendor_token.route_executive)
 app_executive.include_router(operator_account.route_executive)
 app_executive.include_router(operator_role.route_executive)
 app_executive.include_router(operator_role_map.route_executive)
+app_executive.include_router(operator_image.route_executive)
 
 
 # ------------------------------------------------------
@@ -77,6 +79,7 @@ app_operator.include_router(company.route_operator)
 app_operator.include_router(operator_account.route_operator)
 app_operator.include_router(operator_role.route_operator)
 app_operator.include_router(operator_role_map.route_operator)
+app_operator.include_router(operator_image.route_operator)
 
 # ------------------------------------------------------
 # Public routers

--- a/app/api/executive_image.py
+++ b/app/api/executive_image.py
@@ -198,11 +198,14 @@ async def delete_executive_image(
         executive_image = (
             session.query(ExecutiveImage).filter(ExecutiveImage.id == id).first()
         )
-        if executive_image is None or executive_image.executive_id != token.executive_id:
+        if (
+            executive_image is None
+            or executive_image.executive_id != token.executive_id
+        ):
             roles = get_executive_roles(session, token)
             verify_permission(roles, PermissionPath.UPDATE_EXECUTIVE)
 
-        if executive_image is  None:
+        if executive_image is None:
             return Response(status_code=status.HTTP_204_NO_CONTENT)
         executive_image_data = jsonable_encoder(executive_image)
         session.delete(executive_image)

--- a/app/api/executive_image.py
+++ b/app/api/executive_image.py
@@ -198,12 +198,12 @@ async def delete_executive_image(
         executive_image = (
             session.query(ExecutiveImage).filter(ExecutiveImage.id == id).first()
         )
-        if executive_image is None:
-            return Response(status_code=status.HTTP_204_NO_CONTENT)
-        if executive_image.executive_id != token.executive_id:
+        if executive_image is None or executive_image.executive_id != token.executive_id:
             roles = get_executive_roles(session, token)
             verify_permission(roles, PermissionPath.UPDATE_EXECUTIVE)
 
+        if executive_image is  None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
         executive_image_data = jsonable_encoder(executive_image)
         session.delete(executive_image)
         session.commit()

--- a/app/api/executive_image.py
+++ b/app/api/executive_image.py
@@ -21,10 +21,10 @@ from app.src.filters import CreatedOnFilter, IDFilter, PaginationFilter, Picture
 from app.src.urls import URL_EXECUTIVE_PICTURE
 from app.src.minio import delete_file, download_file, upload_file
 from app.api.bearer import oauth2_executive
-from app.src.db import ExecutiveToken, ExecutiveImage, SessionLocal
+from app.src.db import Executive, ExecutiveToken, ExecutiveImage, SessionLocal
 from app.src.permissions.executive import PermissionPath
 from app.src.openobserve import log_event
-from app.src.validators import verify_permission, verify_token
+from app.src.validators import verify_permission, verify_token, validate_id
 from app.src.constants import (
     MAX_IMAGE_FILE_SIZE,
     MAX_IMAGE_RESOLUTION,
@@ -114,6 +114,7 @@ class ImageQueryParams(BaseModel):
             exceptions.InvalidToken(),
             exceptions.NoPermission(),
             exceptions.InvalidImageFile(),
+            exceptions.UnknownValue(ExecutiveImage.executive_id),
         ]
     ),
     description=(
@@ -141,6 +142,12 @@ async def upload_executive_image(
             roles = get_executive_roles(session, token)
             verify_permission(roles, PermissionPath.UPDATE_EXECUTIVE)
 
+        validate_id(
+            session,
+            Executive,
+            form_param.executive_id,
+            ExecutiveImage.executive_id,
+        )
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
         executive_image = ExecutiveImage(

--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -152,7 +152,9 @@ def delete_image(session: Session, operator_image: OperatorImage) -> dict:
             exceptions.InvalidImageFile(),
             exceptions.UnknownValue(OperatorImage.operator_id),
             exceptions.UnknownValue(OperatorImage.company_id),
-            exceptions.InvalidAssociation(OperatorImage.operator_id, OperatorImage.company_id),
+            exceptions.InvalidAssociation(
+                OperatorImage.operator_id, OperatorImage.company_id
+            ),
         ]
     ),
     description=(
@@ -175,7 +177,9 @@ async def upload_operator_image_executive(
         verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR)
 
         validate_id(session, Company, form_param.company_id, OperatorImage.company_id)
-        operator = validate_id(session, Operator, form_param.operator_id, OperatorImage.operator_id)
+        operator = validate_id(
+            session, Operator, form_param.operator_id, OperatorImage.operator_id
+        )
         if operator.company_id != form_param.company_id:
             raise exceptions.InvalidAssociation(
                 OperatorImage.operator_id, OperatorImage.company_id

--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -90,21 +90,32 @@ class CreateFormForOP(ImageUploadForm):
     operator_id: int | None = Field(Form(default=None))
 
 
+class CreateForm(CreateFormForEX):
+    """Generic combined form data for creating a new operator image."""
+
+    pass
+
+
 # Functions
-def create_image(
-    session: Session, operator_image: OperatorImage, file_bytes: bytes
-) -> dict:
+def create_image(session: Session, form_param: CreateForm, file_bytes: bytes) -> dict:
     """
     Creates a new operator image record in the database.
 
     Args:
         session (Session): SQLAlchemy database session.
-        operator_image (OperatorImage): Operator image data to create.
+        form_param (CreateForm): Form data for creating an operator image.
         file_bytes (bytes): The image file bytes.
 
     Returns:
         dict: The created operator image data.
     """
+    operator_image = OperatorImage(
+        company_id=form_param.company_id,
+        operator_id=form_param.operator_id,
+        file_name=form_param.file.filename,
+        file_type=form_param.file.content_type,
+        file_size=len(file_bytes),
+    )
     session.add(operator_image)
     session.flush()
     upload_file(
@@ -119,7 +130,10 @@ def create_image(
     return operator_image_data
 
 
-def delete_image(session: Session, operator_image: OperatorImage) -> dict:
+def delete_image(
+    session: Session,
+    operator_image: OperatorImage,
+) -> dict:
     """
     Deletes an operator image and its associated file from storage.
 
@@ -187,15 +201,10 @@ async def upload_operator_image_executive(
 
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
-        operator_image = OperatorImage(
-            company_id=form_param.company_id,
-            operator_id=form_param.operator_id,
-            file_name=form_param.file.filename,
-            file_type=form_param.file.content_type,
-            file_size=len(file_bytes),
-        )
 
-        operator_image_data = create_image(session, operator_image, file_bytes)
+        operator_image_data = create_image(
+            session, CreateForm(**form_param.model_dump()), file_bytes
+        )
         log_event(token, request_info, operator_image_data)
         return operator_image_data
     except Exception as e:
@@ -294,15 +303,12 @@ async def upload_operator_image(
         )
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
-        operator_image = OperatorImage(
-            company_id=token.company_id,
-            operator_id=form_param.operator_id,
-            file_name=form_param.file.filename,
-            file_type=form_param.file.content_type,
-            file_size=len(file_bytes),
-        )
 
-        operator_image_data = create_image(session, operator_image, file_bytes)
+        operator_image_data = create_image(
+            session,
+            CreateForm(**form_param.model_dump(), company_id=token.company_id),
+            file_bytes,
+        )
         log_event(token, request_info, operator_image_data)
         return operator_image_data
     except Exception as e:

--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -77,7 +77,7 @@ class ImageUploadForm(BaseModel):
     )
 
 
-class CreateFormForEx(ImageUploadForm):
+class CreateFormForEX(ImageUploadForm):
     """Form data for creating a new operator image for an executive."""
 
     company_id: int = Field(Form())
@@ -93,7 +93,7 @@ class CreateFormForOP(ImageUploadForm):
 # Functions
 def create_image(
     session: Session, operator_image: OperatorImage, file_bytes: bytes
-) -> OperatorImage:
+) -> dict:
     """
     Creates a new operator image record in the database.
 
@@ -103,7 +103,7 @@ def create_image(
         file_bytes (bytes): The image file bytes.
 
     Returns:
-        OperatorImage: The created operator image record.
+        dict: The created operator image data.
     """
     session.add(operator_image)
     session.flush()
@@ -150,6 +150,9 @@ def delete_image(session: Session, operator_image: OperatorImage) -> dict:
             exceptions.InvalidToken(),
             exceptions.NoPermission(),
             exceptions.InvalidImageFile(),
+            exceptions.UnknownValue(OperatorImage.operator_id),
+            exceptions.UnknownValue(OperatorImage.company_id),
+            exceptions.InvalidAssociation(OperatorImage.operator_id, OperatorImage.company_id),
         ]
     ),
     description=(
@@ -161,7 +164,7 @@ def delete_image(session: Session, operator_image: OperatorImage) -> dict:
     ),
 )
 async def upload_operator_image_executive(
-    form_param: CreateFormForEx = Depends(),
+    form_param: CreateFormForEX = Depends(),
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
 ):
@@ -171,8 +174,8 @@ async def upload_operator_image_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR)
 
-        validate_id(session, Company, form_param.company_id, Company.id)
-        operator = validate_id(session, Operator, form_param.operator_id, Operator.id)
+        validate_id(session, Company, form_param.company_id, OperatorImage.company_id)
+        operator = validate_id(session, Operator, form_param.operator_id, OperatorImage.operator_id)
         if operator.company_id != form_param.company_id:
             raise exceptions.InvalidAssociation(
                 OperatorImage.operator_id, OperatorImage.company_id
@@ -250,6 +253,7 @@ async def delete_operator_image_executive(
             exceptions.InvalidToken(),
             exceptions.NoPermission(),
             exceptions.InvalidImageFile(),
+            exceptions.UnknownValue(OperatorImage.operator_id),
         ]
     ),
     description=(
@@ -281,7 +285,7 @@ async def upload_operator_image(
             session,
             Operator,
             form_param.operator_id,
-            Operator.id,
+            OperatorImage.operator_id,
             extra_filter=Operator.company_id == token.company_id,
         )
         file_bytes = await form_param.file.read()

--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -13,29 +13,26 @@ from io import BytesIO
 from pydantic import BaseModel, Field
 from sqlalchemy.orm.session import Session
 
-from app.api import executive_image
 from app.src.buckets import OPERATOR_IMAGES
-from app.src.db import OperatorImage, OperatorToken, SessionLocal, ExecutiveToken
+from app.src.db import (
+    Company,
+    OperatorImage,
+    OperatorToken,
+    SessionLocal,
+    ExecutiveToken,
+    Operator,
+)
 from app.api.bearer import oauth2_executive, bearer_operator
-from app.src.enums import OrderIn
-from app.src.filters import IDFilter, PaginationFilter, UpdatedOnFilter, CreatedOnFilter
 from app.src.permissions.operator import PermissionPath as OperatorPermissionPath
 from app.src.permissions.executive import PermissionPath as ExecutivePermissionPath
 from app.src import exceptions
-from app.src.regex import NAME_PATTERN
 from app.src.urls import URL_OPERATOR_PICTURE
-from app.src.minio import delete_file, download_file, upload_file
+from app.src.minio import delete_file, upload_file
 from app.src.openobserve import log_event
-from app.src.validators import verify_permission, verify_token
+from app.src.validators import verify_permission, verify_token, validate_id
 from app.src.functions import (
-    enum_str,
     fuse_exception_responses,
     get_request_info,
-    update_if_changed,
-    apply_id_filters,
-    apply_created_on_filters,
-    apply_updated_on_filters,
-    apply_name_filters,
     get_executive_roles,
     get_operator_roles,
     validate_image,
@@ -81,7 +78,7 @@ class ImageUploadForm(BaseModel):
 
 
 class CreateFormForEx(ImageUploadForm):
-    """Form data for creating a new operator image for an operator."""
+    """Form data for creating a new operator image for an executive."""
 
     company_id: int = Field(Form())
     operator_id: int = Field(Form())
@@ -94,7 +91,7 @@ class CreateFormForOP(ImageUploadForm):
 
 
 # Functions
-def create_operator_image(
+def create_image(
     session: Session, operator_image: OperatorImage, file_bytes: bytes
 ) -> OperatorImage:
     """
@@ -122,7 +119,7 @@ def create_operator_image(
     return operator_image_data
 
 
-def delete_operator_image(session: Session, operator_image: OperatorImage) -> dict:
+def delete_image(session: Session, operator_image: OperatorImage) -> dict:
     """
     Deletes an operator image and its associated file from storage.
 
@@ -158,9 +155,8 @@ def delete_operator_image(session: Session, operator_image: OperatorImage) -> di
     description=(
         """
             **Uploads an operator image.**    
-            - Operator must have a valid access token.    
-            - Logged-in operator must have `operator.update` permission to upload other operator images.    
-            - Operator can update their own image without permission.    
+            - Executive must have a valid access token.    
+            - Logged-in executive must have `company.operator.update` permission to upload other operator images.    
         """
     ),
 )
@@ -175,6 +171,13 @@ async def upload_operator_image_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR)
 
+        validate_id(session, Company, form_param.company_id, Company.id)
+        operator = validate_id(session, Operator, form_param.operator_id, Operator.id)
+        if operator.company_id != form_param.company_id:
+            raise exceptions.InvalidAssociation(
+                OperatorImage.operator_id, OperatorImage.company_id
+            )
+
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
         operator_image = OperatorImage(
@@ -184,7 +187,8 @@ async def upload_operator_image_executive(
             file_type=form_param.file.content_type,
             file_size=len(file_bytes),
         )
-        operator_image_data = create_operator_image(session, operator_image, file_bytes)
+
+        operator_image_data = create_image(session, operator_image, file_bytes)
         log_event(token, request_info, operator_image_data)
         return operator_image_data
     except Exception as e:
@@ -203,9 +207,8 @@ async def upload_operator_image_executive(
     description=(
         """
             **Deletes an operator image.**    
-            - Operator must have a valid access token.    
-            - Operators can delete their own image without additional permissions.    
-            - To delete another operator's image, the `company.operator.update` permission is required.    
+            - Executive must have a valid access token.       
+            - To delete operator's image, the `company.operator.update` permission is required.    
             - Returns 204 No Content even if the specified image does not exist.    
         """
     ),
@@ -225,7 +228,7 @@ async def delete_operator_image_executive(
             session.query(OperatorImage).filter(OperatorImage.id == id).first()
         )
         if operator_image is not None:
-            operator_image_data = delete_operator_image(session, operator_image)
+            operator_image_data = delete_image(session, operator_image)
             log_event(token, request_info, operator_image_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
@@ -253,7 +256,7 @@ async def delete_operator_image_executive(
         """
             **Uploads an operator image.**    
             - Operator must have a valid access token.    
-            - Logged-in operator must have `operator.update` permission to upload other operator images.    
+            - Logged-in operator must have `company.operator.update` permission to upload other operator images.    
             - Operator can update their own image without permission.    
         """
     ),
@@ -274,6 +277,13 @@ async def upload_operator_image(
             roles = get_operator_roles(session, token)
             verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_OPERATOR)
 
+        validate_id(
+            session,
+            Operator,
+            form_param.operator_id,
+            Operator.id,
+            extra_filter=Operator.company_id == token.company_id,
+        )
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
         operator_image = OperatorImage(
@@ -283,7 +293,8 @@ async def upload_operator_image(
             file_type=form_param.file.content_type,
             file_size=len(file_bytes),
         )
-        operator_image_data = create_operator_image(session, operator_image, file_bytes)
+
+        operator_image_data = create_image(session, operator_image, file_bytes)
         log_event(token, request_info, operator_image_data)
         return operator_image_data
     except Exception as e:
@@ -304,8 +315,8 @@ async def upload_operator_image(
             **Deletes an operator image.**    
             - Operator must have a valid access token.    
             - Operators can delete their own image without additional permissions.    
-            - To delete another operator's image, the `operator.update` permission is required.    
-            - Returns 204 No Content even if the specified image does not exist.      
+            - To delete another operator's image, the `company.operator.update` permission is required.    
+            - Returns 204 No Content even if the specified image does not exist.    
         """
     ),
 )
@@ -325,11 +336,12 @@ async def delete_operator_image(
             )
             .first()
         )
-        if operator_image.operator_id != token.operator_id:
+        if operator_image is None or operator_image.operator_id != token.operator_id:
             roles = get_operator_roles(session, token)
             verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_OPERATOR)
-
-        operator_image_data = delete_operator_image(session, operator_image)
+        if operator_image is None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        operator_image_data = delete_image(session, operator_image)
         log_event(token, request_info, operator_image_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:

--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -31,6 +31,9 @@ from app.src.functions import (
     update_if_changed,
     apply_id_filters,   apply_created_on_filters,
     apply_updated_on_filters,   apply_name_filters,
+    get_executive_roles,
+    get_operator_roles,
+    validate_image,
 )
 from app.src.constants import (
     MAX_IMAGE_FILE_SIZE,
@@ -116,26 +119,27 @@ async def upload_operator_image_executive(
 
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
-        executive_image = ExecutiveImage(
-            executive_id=form_param.executive_id,
+        operator_image = OperatorImage(
+            company_id=form_param.company_id,
+            operator_id=form_param.operator_id,
             file_name=form_param.file.filename,
             file_type=form_param.file.content_type,
             file_size=len(file_bytes),
         )
-        session.add(executive_image)
+        session.add(operator_image_image)
         session.flush()
         upload_file(
-            EXECUTIVE_IMAGES,
-            str(executive_image.id),
+            OPERATOR_IMAGES_IMAGES,
+            str(operator_image.id),
             len(file_bytes),
             BytesIO(file_bytes),
         )
         session.commit()
-        session.refresh(executive_image)
+        session.refresh(operator_image)
 
-        executive_image_data = jsonable_encoder(executive_image)
-        log_event(token, request_info, executive_image_data)
-        return executive_image_data
+        operator_image_data = jsonable_encoder(operator_image)
+        log_event(token, request_info, operator_image_data)
+        return operator_image_data
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -64,10 +64,11 @@ class OperatorImageSchema(BaseModel):
 
 
 ## Input Forms
-class CreateFormForOP(BaseModel):
+class CreateFormForEx(BaseModel):
     """Form data for creating a new operator image for an operator."""
-
-    operator_id: int | None = Field(Form(default=None))
+   
+    company_id: int = Field(Form())
+    operator_id: int = Field(Form())
     file: UploadFile = Field(
         File(
             description=(
@@ -80,10 +81,10 @@ class CreateFormForOP(BaseModel):
     )
 
 
-class CreateFormForEX(CreateFormForOP):
-    """Form data for creating a new operator image for an executive."""
+class CreateFormForOP(BaseModel):
+    """Form data for creating a new operator image for an operator."""
 
-    company_id: int = Field(Form())
+    operator_id: int | None = Field(Form(default=None))
 
 
 # ---------------------------------------------------------------------------
@@ -121,6 +122,7 @@ async def upload_operator_image_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR)
 
+        
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
         operator_image = OperatorImage(

--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Form, File, UploadFile, Response, status, Depends
 from fastapi.encoders import jsonable_encoder
 from io import BytesIO
 from pydantic import BaseModel, Field
+from sqlalchemy.orm.session import Session
 
 from app.api import executive_image
 from app.src.buckets import OPERATOR_IMAGES
@@ -64,11 +65,9 @@ class OperatorImageSchema(BaseModel):
 
 
 ## Input Forms
-class CreateFormForEx(BaseModel):
-    """Form data for creating a new operator image for an operator."""
-   
-    company_id: int = Field(Form())
-    operator_id: int = Field(Form())
+class ImageUploadForm(BaseModel):
+    """Form data for uploading an operator image."""
+
     file: UploadFile = Field(
         File(
             description=(
@@ -81,10 +80,64 @@ class CreateFormForEx(BaseModel):
     )
 
 
-class CreateFormForOP(BaseModel):
+class CreateFormForEx(ImageUploadForm):
+    """Form data for creating a new operator image for an operator."""
+
+    company_id: int = Field(Form())
+    operator_id: int = Field(Form())
+
+
+class CreateFormForOP(ImageUploadForm):
     """Form data for creating a new operator image for an operator."""
 
     operator_id: int | None = Field(Form(default=None))
+
+
+# Functions
+def create_operator_image(
+    session: Session, operator_image: OperatorImage, file_bytes: bytes
+) -> OperatorImage:
+    """
+    Creates a new operator image record in the database.
+
+    Args:
+        session (Session): SQLAlchemy database session.
+        operator_image (OperatorImage): Operator image data to create.
+        file_bytes (bytes): The image file bytes.
+
+    Returns:
+        OperatorImage: The created operator image record.
+    """
+    session.add(operator_image)
+    session.flush()
+    upload_file(
+        OPERATOR_IMAGES,
+        str(operator_image.id),
+        len(file_bytes),
+        BytesIO(file_bytes),
+    )
+    session.commit()
+    session.refresh(operator_image)
+    operator_image_data = jsonable_encoder(operator_image)
+    return operator_image_data
+
+
+def delete_operator_image(session: Session, operator_image: OperatorImage) -> dict:
+    """
+    Deletes an operator image and its associated file from storage.
+
+    Args:
+        session (Session): SQLAlchemy database session.
+        operator_image (OperatorImage): Operator image to delete.
+
+    Returns:
+        dict: deleted operator image data for logging purposes.
+    """
+    operator_image_data = jsonable_encoder(operator_image)
+    session.delete(operator_image)
+    session.commit()
+    delete_file(OPERATOR_IMAGES, str(operator_image.id))
+    return operator_image_data
 
 
 # ---------------------------------------------------------------------------
@@ -105,14 +158,14 @@ class CreateFormForOP(BaseModel):
     description=(
         """
             **Uploads an operator image.**    
-            - Operator must have a valid access token.   
-            - Logged-in operator must have `operator.update` permission to upload other operator images.   
+            - Operator must have a valid access token.    
+            - Logged-in operator must have `operator.update` permission to upload other operator images.    
             - Operator can update their own image without permission.    
         """
     ),
 )
 async def upload_operator_image_executive(
-    form_param: CreateFormForEX = Depends(),
+    form_param: CreateFormForEx = Depends(),
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
 ):
@@ -122,7 +175,6 @@ async def upload_operator_image_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR)
 
-        
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
         operator_image = OperatorImage(
@@ -132,20 +184,50 @@ async def upload_operator_image_executive(
             file_type=form_param.file.content_type,
             file_size=len(file_bytes),
         )
-        session.add(operator_image)
-        session.flush()
-        upload_file(
-            OPERATOR_IMAGES,
-            str(operator_image.id),
-            len(file_bytes),
-            BytesIO(file_bytes),
-        )
-        session.commit()
-        session.refresh(operator_image)
-
-        operator_image_data = jsonable_encoder(operator_image)
+        operator_image_data = create_operator_image(session, operator_image, file_bytes)
         log_event(token, request_info, operator_image_data)
         return operator_image_data
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_executive.delete(
+    f"{URL_OPERATOR_PICTURE}/{{id}}",
+    tags=["Operator Account Image"],
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
+    description=(
+        """
+            **Deletes an operator image.**    
+            - Operator must have a valid access token.    
+            - Operators can delete their own image without additional permissions.    
+            - To delete another operator's image, the `company.operator.update` permission is required.    
+            - Returns 204 No Content even if the specified image does not exist.    
+        """
+    ),
+)
+async def delete_operator_image_executive(
+    id: int,
+    access_token=Depends(oauth2_executive),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, ExecutiveToken, access_token)
+        roles = get_executive_roles(session, token)
+        verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR)
+
+        operator_image = (
+            session.query(OperatorImage).filter(OperatorImage.id == id).first()
+        )
+        if operator_image is not None:
+            operator_image_data = delete_operator_image(session, operator_image)
+            log_event(token, request_info, operator_image_data)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -170,8 +252,8 @@ async def upload_operator_image_executive(
     description=(
         """
             **Uploads an operator image.**    
-            - Operator must have a valid access token.   
-            - Logged-in operator must have `operator.update` permission to upload other operator images.   
+            - Operator must have a valid access token.    
+            - Logged-in operator must have `operator.update` permission to upload other operator images.    
             - Operator can update their own image without permission.    
         """
     ),
@@ -201,20 +283,55 @@ async def upload_operator_image(
             file_type=form_param.file.content_type,
             file_size=len(file_bytes),
         )
-        session.add(operator_image)
-        session.flush()
-        upload_file(
-            OPERATOR_IMAGES,
-            str(operator_image.id),
-            len(file_bytes),
-            BytesIO(file_bytes),
-        )
-        session.commit()
-        session.refresh(operator_image)
-
-        operator_image_data = jsonable_encoder(operator_image)
+        operator_image_data = create_operator_image(session, operator_image, file_bytes)
         log_event(token, request_info, operator_image_data)
         return operator_image_data
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+@route_operator.delete(
+    f"{URL_OPERATOR_PICTURE}/{{id}}",
+    tags=["Account Image"],
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses=fuse_exception_responses(
+        [exceptions.InvalidToken(), exceptions.NoPermission()]
+    ),
+    description=(
+        """
+            **Deletes an operator image.**    
+            - Operator must have a valid access token.    
+            - Operators can delete their own image without additional permissions.    
+            - To delete another operator's image, the `operator.update` permission is required.    
+            - Returns 204 No Content even if the specified image does not exist.      
+        """
+    ),
+)
+async def delete_operator_image(
+    id: int,
+    access_token=Depends(bearer_operator),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, OperatorToken, access_token.credentials)
+
+        operator_image = (
+            session.query(OperatorImage)
+            .filter(
+                OperatorImage.id == id, OperatorImage.company_id == token.company_id
+            )
+            .first()
+        )
+        if operator_image.operator_id != token.operator_id:
+            roles = get_operator_roles(session, token)
+            verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_OPERATOR)
+
+        operator_image_data = delete_operator_image(session, operator_image)
+        log_event(token, request_info, operator_image_data)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -1,0 +1,142 @@
+"""
+Operator Image API Router for EnteBus.
+
+Provides endpoints for managing operator images, including creation, deletion.
+Uses Pydantic schemas for input validation and structured output.
+Endpoints for retrieval are planned for future implementation.
+"""
+
+from datetime import datetime
+from fastapi import APIRouter, Form, File, UploadFile, Response, status, Depends
+from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel, Field
+
+from app.src.buckets import OPERATOR_IMAGES
+from app.src.db import OperatorImage, OperatorToken, SessionLocal, ExecutiveToken
+from app.api.bearer import oauth2_executive, bearer_operator
+from app.src.enums import OrderIn
+from app.src.filters import IDFilter, PaginationFilter, UpdatedOnFilter, CreatedOnFilter
+from app.src.permissions.operator import PermissionPath
+from app.src import exceptions
+from app.src.regex import NAME_PATTERN
+from app.src.urls import URL_OPERATOR_IMAGE, URL_OPERATOR_PICTURE
+from app.src.minio import delete_file, download_file, upload_file
+from app.src.openobserve import log_event
+from app.src.validators import verify_permission, verify_token
+from app.src.functions import (
+    enum_str,
+    fuse_exception_responses,
+    get_request_info,
+    get_operator_images,
+    update_if_changed,
+    apply_id_filters,   apply_created_on_filters,
+    apply_updated_on_filters,   apply_name_filters,
+)
+from app.src.constants import (
+    MAX_IMAGE_FILE_SIZE,
+    MAX_IMAGE_RESOLUTION,
+    MIN_IMAGE_FILE_SIZE,
+    MIN_IMAGE_RESOLUTION,
+)
+
+route_executive = APIRouter()
+route_operator = APIRouter()
+
+
+## Output Schema
+class OperatorImageSchema(BaseModel):
+    """Schema for operator image response."""
+
+    id: int
+    company_id: int
+    operator_id: int
+    file_name: str
+    file_type: str
+    file_size: int
+    created_on: datetime
+
+
+## Input Forms
+class CreateForm(BaseModel):
+    """Form data for creating a new operator image."""
+
+    company_id: int | None = Field(Form(default=None))
+    operator_id: int | None = Field(Form(default=None))
+    file: UploadFile = Field(
+        File(
+            description=(
+                f"Max File Size: {MAX_IMAGE_FILE_SIZE // (1024*1024)} MB, "
+                f"Min File Size: {MIN_IMAGE_FILE_SIZE // 1024} KB, "
+                f"Max Resolution: {MAX_IMAGE_RESOLUTION} x {MAX_IMAGE_RESOLUTION} px, "
+                f"Min Resolution: {MIN_IMAGE_RESOLUTION} x {MIN_IMAGE_RESOLUTION} px"
+            )
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+## API endpoints [Executive]
+# ---------------------------------------------------------------------------
+@route_executive.post(
+    URL_OPERATOR_PICTURE,
+    tags=["Operator Account Image"],
+    response_model=OperatorImageSchema,
+    status_code=status.HTTP_201_CREATED,
+    responses=fuse_exception_responses(
+        [
+            exceptions.InvalidToken(),
+            exceptions.NoPermission(),
+            exceptions.InvalidImageFile(),
+        ]
+    ),
+    description=(
+        """
+            **Uploads an operator image.**    
+            - Operator must have a valid access token.   
+            - Logged-in operator must have `operator.update` permission to upload other operator images.   
+            - Operator can update their own image without permission.    
+        """
+    ),
+)
+async def upload_operator_image_executive(
+    form_param: CreateForm = Depends(),
+    access_token=Depends(oauth2_executive),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, ExecutiveToken, access_token)
+
+        if form_param.executive_id is None:
+            form_param.executive_id = token.executive_id
+        is_self_update = form_param.executive_id == token.executive_id
+        if not is_self_update:
+            roles = get_executive_roles(session, token)
+            verify_permission(roles, PermissionPath.UPDATE_EXECUTIVE)
+
+        file_bytes = await form_param.file.read()
+        validate_image(file_bytes, form_param.file.filename)
+        executive_image = ExecutiveImage(
+            executive_id=form_param.executive_id,
+            file_name=form_param.file.filename,
+            file_type=form_param.file.content_type,
+            file_size=len(file_bytes),
+        )
+        session.add(executive_image)
+        session.flush()
+        upload_file(
+            EXECUTIVE_IMAGES,
+            str(executive_image.id),
+            len(file_bytes),
+            BytesIO(file_bytes),
+        )
+        session.commit()
+        session.refresh(executive_image)
+
+        executive_image_data = jsonable_encoder(executive_image)
+        log_event(token, request_info, executive_image_data)
+        return executive_image_data
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()

--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -9,17 +9,20 @@ Endpoints for retrieval are planned for future implementation.
 from datetime import datetime
 from fastapi import APIRouter, Form, File, UploadFile, Response, status, Depends
 from fastapi.encoders import jsonable_encoder
+from io import BytesIO
 from pydantic import BaseModel, Field
 
+from app.api import executive_image
 from app.src.buckets import OPERATOR_IMAGES
 from app.src.db import OperatorImage, OperatorToken, SessionLocal, ExecutiveToken
 from app.api.bearer import oauth2_executive, bearer_operator
 from app.src.enums import OrderIn
 from app.src.filters import IDFilter, PaginationFilter, UpdatedOnFilter, CreatedOnFilter
-from app.src.permissions.operator import PermissionPath
+from app.src.permissions.operator import PermissionPath as OperatorPermissionPath
+from app.src.permissions.executive import PermissionPath as ExecutivePermissionPath
 from app.src import exceptions
 from app.src.regex import NAME_PATTERN
-from app.src.urls import URL_OPERATOR_IMAGE, URL_OPERATOR_PICTURE
+from app.src.urls import URL_OPERATOR_PICTURE
 from app.src.minio import delete_file, download_file, upload_file
 from app.src.openobserve import log_event
 from app.src.validators import verify_permission, verify_token
@@ -27,10 +30,11 @@ from app.src.functions import (
     enum_str,
     fuse_exception_responses,
     get_request_info,
-    get_operator_images,
     update_if_changed,
-    apply_id_filters,   apply_created_on_filters,
-    apply_updated_on_filters,   apply_name_filters,
+    apply_id_filters,
+    apply_created_on_filters,
+    apply_updated_on_filters,
+    apply_name_filters,
     get_executive_roles,
     get_operator_roles,
     validate_image,
@@ -60,10 +64,9 @@ class OperatorImageSchema(BaseModel):
 
 
 ## Input Forms
-class CreateForm(BaseModel):
-    """Form data for creating a new operator image."""
+class CreateFormForOP(BaseModel):
+    """Form data for creating a new operator image for an operator."""
 
-    company_id: int | None = Field(Form(default=None))
     operator_id: int | None = Field(Form(default=None))
     file: UploadFile = Field(
         File(
@@ -75,6 +78,12 @@ class CreateForm(BaseModel):
             )
         )
     )
+
+
+class CreateFormForEX(CreateFormForOP):
+    """Form data for creating a new operator image for an executive."""
+
+    company_id: int = Field(Form())
 
 
 # ---------------------------------------------------------------------------
@@ -102,20 +111,15 @@ class CreateForm(BaseModel):
     ),
 )
 async def upload_operator_image_executive(
-    form_param: CreateForm = Depends(),
+    form_param: CreateFormForEX = Depends(),
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
 ):
     try:
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, access_token)
-
-        if form_param.executive_id is None:
-            form_param.executive_id = token.executive_id
-        is_self_update = form_param.executive_id == token.executive_id
-        if not is_self_update:
-            roles = get_executive_roles(session, token)
-            verify_permission(roles, PermissionPath.UPDATE_EXECUTIVE)
+        roles = get_executive_roles(session, token)
+        verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR)
 
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
@@ -126,10 +130,79 @@ async def upload_operator_image_executive(
             file_type=form_param.file.content_type,
             file_size=len(file_bytes),
         )
-        session.add(operator_image_image)
+        session.add(operator_image)
         session.flush()
         upload_file(
-            OPERATOR_IMAGES_IMAGES,
+            OPERATOR_IMAGES,
+            str(operator_image.id),
+            len(file_bytes),
+            BytesIO(file_bytes),
+        )
+        session.commit()
+        session.refresh(operator_image)
+
+        operator_image_data = jsonable_encoder(operator_image)
+        log_event(token, request_info, operator_image_data)
+        return operator_image_data
+    except Exception as e:
+        exceptions.handle(e)
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+## API endpoints [Operator]
+# ---------------------------------------------------------------------------
+@route_operator.post(
+    URL_OPERATOR_PICTURE,
+    tags=["Account Image"],
+    response_model=OperatorImageSchema,
+    status_code=status.HTTP_201_CREATED,
+    responses=fuse_exception_responses(
+        [
+            exceptions.InvalidToken(),
+            exceptions.NoPermission(),
+            exceptions.InvalidImageFile(),
+        ]
+    ),
+    description=(
+        """
+            **Uploads an operator image.**    
+            - Operator must have a valid access token.   
+            - Logged-in operator must have `operator.update` permission to upload other operator images.   
+            - Operator can update their own image without permission.    
+        """
+    ),
+)
+async def upload_operator_image(
+    form_param: CreateFormForOP = Depends(),
+    access_token=Depends(bearer_operator),
+    request_info=Depends(get_request_info),
+):
+    try:
+        session = SessionLocal()
+        token = verify_token(session, OperatorToken, access_token.credentials)
+
+        if form_param.operator_id is None:
+            form_param.operator_id = token.operator_id
+        is_self_update = form_param.operator_id == token.operator_id
+        if not is_self_update:
+            roles = get_operator_roles(session, token)
+            verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_OPERATOR)
+
+        file_bytes = await form_param.file.read()
+        validate_image(file_bytes, form_param.file.filename)
+        operator_image = OperatorImage(
+            company_id=token.company_id,
+            operator_id=form_param.operator_id,
+            file_name=form_param.file.filename,
+            file_type=form_param.file.content_type,
+            file_size=len(file_bytes),
+        )
+        session.add(operator_image)
+        session.flush()
+        upload_file(
+            OPERATOR_IMAGES,
             str(operator_image.id),
             len(file_bytes),
             BytesIO(file_bytes),


### PR DESCRIPTION
### **Summary of Changes**
- Added POST endpoints for operator image in the Executive and Operator apps.
- Added DELETE endpoints for operator image in the Executive and Operator apps.
- Validated the token before execution.
- Checked permissions before allowing creation and deletion
- Fixed incorrect success response in executive image deletion; now returns 403 for unauthorized requests
### **How to Test / Verify**

- Make sure operator image creation works as expected.
- Make sure operator image deletion works as expected.



### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
