### PR TITLE
Fix route conflict in service service assignment and duty endpoints

### DIFF
--- a/app/api/controller.py
+++ b/app/api/controller.py
@@ -80,8 +80,8 @@ app_executive.include_router(route.route_executive)
 app_executive.include_router(landmark_in_route.route_executive)
 app_executive.include_router(fare.route_executive)
 app_executive.include_router(duty.route_executive)
-app_executive.include_router(service.route_executive)
 app_executive.include_router(service_assignment.route_executive)
+app_executive.include_router(service.route_executive)
 app_executive.include_router(paper_ticket.route_executive)
 
 
@@ -118,8 +118,8 @@ app_operator.include_router(route.route_operator)
 app_operator.include_router(landmark_in_route.route_operator)
 app_operator.include_router(fare.route_operator)
 app_operator.include_router(duty.route_operator)
-app_operator.include_router(service.route_operator)
 app_operator.include_router(service_assignment.route_operator)
+app_operator.include_router(service.route_operator)
 app_operator.include_router(paper_ticket.route_operator)
 
 


### PR DESCRIPTION
### **Summary of Changes**
- Fixed route conflict between dynamic (/company/service/{id}) and static (/company/service/assignment) endpoints
- Updated router registration order in controller.py so static routes are evaluated before dynamic routes
- Verified and ensured similar conflicts do not occur in Duty-related endpoints

### **How to Test / Verify**

-  Make sure the service assignment endpoint is working as expected
-  Make sure the duty endpoints are working as expected


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
