### PR TITLE
Generate default template dict for permission schemas

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -33,6 +33,10 @@ from app.src.db import (
     VendorRoleMap,
 )
 
+from app.src.permissions.executive import PermissionSchema as PermissionSchemaEX
+from app.src.permissions.vendor import PermissionSchema as PermissionSchemaVN
+from app.src.permissions.operator import PermissionSchema as PermissionSchemaOP
+
 
 def _alembic_cfg() -> Config:
     alembic_cfg = Config("app/alembic.ini")
@@ -114,6 +118,7 @@ def initialize():
     """Initialize the database with default users with default permissions."""
     session = SessionLocal()
 
+    # Create default executives admin and guest
     admin = Executive(
         username="admin",
         password="password",
@@ -126,126 +131,23 @@ def initialize():
         full_name="Entebus guest",
         designation="Guest",
     )
-
     session.add_all([admin, guest])
     session.flush()
 
-    admin_permissions = {
-        "landmark": {
-            "create": True,
-            "update": True,
-            "delete": True,
-            "bus_stop": {"create": True, "update": True, "delete": True},
-        },
-        "fare": {"create": True, "update": True, "delete": True},
-        "executive": {
-            "create": True,
-            "update": True,
-            "delete": True,
-            "role": {"create": True, "update": True, "delete": True},
-            "token": {"fetch": True, "delete": True},
-        },
-        "business": {
-            "create": True,
-            "update": True,
-            "delete": True,
-            "vendor": {
-                "create": True,
-                "update": True,
-                "delete": True,
-                "role": {"create": True, "update": True, "delete": True},
-                "token": {"fetch": True, "delete": True},
-            },
-        },
-        "company": {
-            "create": True,
-            "update": True,
-            "delete": True,
-            "vehicle": {"create": True, "update": True, "delete": True},
-            "fare": {"create": True, "update": True, "delete": True},
-            "route": {"create": True, "update": True, "delete": True},
-            "operator": {
-                "create": True,
-                "update": True,
-                "delete": True,
-                "role": {"create": True, "update": True, "delete": True},
-                "token": {"fetch": True, "delete": True},
-            },
-            "service": {
-                "create": True,
-                "update": True,
-                "delete": True,
-                "duty": {"update": True},
-                "assignment": {"create": True, "update": True, "delete": True},
-                "statement": {"create": True},
-            },
-            "schedule": {"create": True, "update": True, "delete": True},
-        },
-    }
-
-    guest_permissions = {
-        "landmark": {
-            "create": False,
-            "update": False,
-            "delete": False,
-            "bus_stop": {"create": False, "update": False, "delete": False},
-        },
-        "fare": {"create": False, "update": False, "delete": False},
-        "executive": {
-            "create": False,
-            "update": False,
-            "delete": False,
-            "role": {"create": False, "update": False, "delete": False},
-            "token": {"fetch": False, "delete": False},
-        },
-        "business": {
-            "create": False,
-            "update": False,
-            "delete": False,
-            "vendor": {
-                "create": False,
-                "update": False,
-                "delete": False,
-                "role": {"create": False, "update": False, "delete": False},
-                "token": {"fetch": False, "delete": False},
-            },
-        },
-        "company": {
-            "create": False,
-            "update": False,
-            "delete": False,
-            "vehicle": {"create": False, "update": False, "delete": False},
-            "fare": {"create": False, "update": False, "delete": False},
-            "route": {"create": False, "update": False, "delete": False},
-            "operator": {
-                "create": False,
-                "update": False,
-                "delete": False,
-                "role": {"create": False, "update": False, "delete": False},
-                "token": {"fetch": False, "delete": False},
-            },
-            "service": {
-                "create": False,
-                "update": False,
-                "delete": False,
-                "duty": {"update": False},
-                "assignment": {"create": False, "update": False, "delete": False},
-                "statement": {"create": False},
-            },
-            "schedule": {"create": False, "update": False, "delete": False},
-        },
-    }
-
+    # Create roles for executives
+    admin_permissions = PermissionSchemaEX.all_granted().model_dump()
+    guest_permissions = PermissionSchemaEX.all_denied().model_dump()
     admin_role = ExecutiveRole(name="Admin", permissions=admin_permissions)
     guest_role = ExecutiveRole(name="Guest", permissions=guest_permissions)
-
     session.add_all([admin_role, guest_role])
     session.flush()
 
+    # Map executives to roles
     admin_role_map = ExecutiveRoleMap(role_id=admin_role.id, executive_id=admin.id)
     guest_role_map = ExecutiveRoleMap(role_id=guest_role.id, executive_id=guest.id)
     session.add_all([admin_role_map, guest_role_map])
 
+    # Create a default company
     company = Company(
         name="Nixbug Softwares OPC Pvt Ltd",
         status=CompanyStatus.VERIFIED,
@@ -254,14 +156,19 @@ def initialize():
     )
     session.add(company)
     session.flush()
+    
+    # Create company wallet
     wallet = Wallet(balance=0.0, name=company.name)
     session.add(wallet)
     session.flush()
+    
+    # Map the company to its wallet
     company_wallet_map = CompanyWallet(company_id=company.id, wallet_id=wallet.id)
     session.add(company_wallet_map)
     session.flush()
 
-    operator = Operator(
+    # Create default operators admin and guest for the company
+    admin = Operator(
         company_id=company.id,
         username="admin",
         password="password",
@@ -272,35 +179,6 @@ def initialize():
         phone_number="+91-9496801157",
         email_id="contact@nixbug.com",
     )
-    session.add(operator)
-    session.flush()
-
-    admin_permissions = {
-        "company": {
-            "update": True,
-            "vehicle": {"create": True, "update": True, "delete": True},
-            "fare": {"create": True, "update": True, "delete": True},
-            "route": {"create": True, "update": True, "delete": True},
-            "operator": {
-                "create": True,
-                "update": True,
-                "delete": True,
-                "role": {"create": True, "update": True, "delete": True},
-                "token": {"fetch": True, "delete": True},
-            },
-            "service": {
-                "create": True,
-                "update": True,
-                "delete": True,
-                "duty": {"update": True},
-                "assignment": {"create": True, "update": True, "delete": True},
-                "ticket": {"create": True},
-                "statement": {"create": True},
-            },
-            "schedule": {"create": True, "update": True, "delete": True},
-        },
-    }
-
     guest = Operator(
         company_id=company.id,
         username="guest",
@@ -312,55 +190,32 @@ def initialize():
         phone_number="+91-9496801111",
         email_id="contact@nixbug.com",
     )
-    session.add(guest)
+    session.add_all([admin, guest])
     session.flush()
 
-    guest_permissions = {
-        "company": {
-            "update": False,
-            "vehicle": {"create": False, "update": False, "delete": False},
-            "fare": {"create": False, "update": False, "delete": False},
-            "route": {"create": False, "update": False, "delete": False},
-            "operator": {
-                "create": False,
-                "update": False,
-                "delete": False,
-                "role": {"create": False, "update": False, "delete": False},
-                "token": {"fetch": False, "delete": False},
-            },
-            "service": {
-                "create": False,
-                "update": False,
-                "delete": False,
-                "duty": {"update": False},
-                "assignment": {"create": False, "update": False, "delete": False},
-                "ticket": {"create": False},
-                "statement": {"create": False},
-            },
-            "schedule": {"create": False, "update": False, "delete": False},
-        },
-    }
-
+    # Create roles for operators within the company
+    admin_permissions = PermissionSchemaOP.all_granted().model_dump()
+    guest_permissions = PermissionSchemaOP.all_denied().model_dump()
     admin_role = OperatorRole(
         company_id=company.id, name="Admin", permissions=admin_permissions
     )
     guest_role = OperatorRole(
         company_id=company.id, name="Guest", permissions=guest_permissions
     )
-
     session.add_all([admin_role, guest_role])
     session.flush()
 
+    # Map operators to roles
     admin_role_map = OperatorRoleMap(
-        company_id=company.id, role_id=admin_role.id, operator_id=operator.id
+        company_id=company.id, role_id=admin_role.id, operator_id=admin.id
     )
-    session.add_all([admin_role_map])
-
     guest_role_map = OperatorRoleMap(
         company_id=company.id, role_id=guest_role.id, operator_id=guest.id
     )
-    session.add_all([guest_role_map])
+    session.add_all([admin_role_map, guest_role_map])
+    session.flush()
 
+    # Create a default business
     business = Business(
         name="Nixbug Softwares OPC Pvt Ltd",
         status=BusinessStatus.ACTIVE,
@@ -370,7 +225,8 @@ def initialize():
     session.add(business)
     session.flush()
 
-    admin_vendor = Vendor(
+    # Create default vendors admin and guest for the business
+    admin = Vendor(
         business_id=business.id,
         username="admin",
         password="password",
@@ -381,10 +237,7 @@ def initialize():
         phone_number="+91-9496801157",
         email_id="contact@nixbug.com",
     )
-    session.add(admin_vendor)
-    session.flush()
-
-    guest_vendor = Vendor(
+    guest = Vendor(
         business_id=business.id,
         username="guest",
         password="password",
@@ -395,68 +248,30 @@ def initialize():
         phone_number="+91-9496801111",
         email_id="contacthr@nixbug.com",
     )
-    session.add(guest_vendor)
+    session.add_all([admin, guest])
     session.flush()
 
-    admin_permissions = {
-        "business": {
-            "update": True,
-            "vendor": {
-                "create": True,
-                "update": True,
-                "delete": True,
-                "role": {
-                    "create": True,
-                    "update": True,
-                    "delete": True,
-                },
-                "token": {
-                    "fetch": True,
-                    "delete": True,
-                },
-            },
-        }
-    }
-
-    guest_permissions = {
-        "business": {
-            "update": False,
-            "vendor": {
-                "create": False,
-                "update": False,
-                "delete": False,
-                "role": {
-                    "create": False,
-                    "update": False,
-                    "delete": False,
-                },
-                "token": {
-                    "fetch": False,
-                    "delete": False,
-                },
-            },
-        }
-    }
-
+    # Create roles for vendors within the business
+    admin_permissions = PermissionSchemaVN.all_granted().model_dump()
+    guest_permissions = PermissionSchemaVN.all_denied().model_dump()
     admin_role = VendorRole(
         business_id=business.id, name="Admin", permissions=admin_permissions
     )
     guest_role = VendorRole(
         business_id=business.id, name="Guest", permissions=guest_permissions
     )
-
     session.add_all([admin_role, guest_role])
     session.flush()
 
+    # Map vendors to roles
     admin_role_map = VendorRoleMap(
-        business_id=business.id, role_id=admin_role.id, vendor_id=admin_vendor.id
+        business_id=business.id, role_id=admin_role.id, vendor_id=admin.id
     )
-    session.add_all([admin_role_map])
-
     guest_role_map = VendorRoleMap(
-        business_id=business.id, role_id=guest_role.id, vendor_id=guest_vendor.id
+        business_id=business.id, role_id=guest_role.id, vendor_id=guest.id
     )
-    session.add_all([guest_role_map])
+    session.add_all([admin_role_map, guest_role_map])
+    session.flush()
 
     session.commit()
     print("* Initialization completed")

--- a/app/setup.py
+++ b/app/setup.py
@@ -156,12 +156,12 @@ def initialize():
     )
     session.add(company)
     session.flush()
-    
+
     # Create company wallet
     wallet = Wallet(balance=0.0, name=company.name)
     session.add(wallet)
     session.flush()
-    
+
     # Map the company to its wallet
     company_wallet_map = CompanyWallet(company_id=company.id, wallet_id=wallet.id)
     session.add(company_wallet_map)

--- a/app/src/permissions/base.py
+++ b/app/src/permissions/base.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel
+
+
+class PermissionBase(BaseModel):
+    @classmethod
+    def all_granted(cls):
+        return cls(
+            **{
+                name: (
+                    field.annotation.all_granted()  # recurse if nested model
+                    if isinstance(field.annotation, type)
+                    and issubclass(field.annotation, BaseModel)
+                    else True  # leaf bool field
+                )
+                for name, field in cls.model_fields.items()
+            }
+        )
+
+    @classmethod
+    def all_denied(cls):
+        return cls(
+            **{
+                name: (
+                    field.annotation.all_denied()
+                    if isinstance(field.annotation, type)
+                    and issubclass(field.annotation, BaseModel)
+                    else False
+                )
+                for name, field in cls.model_fields.items()
+            }
+        )

--- a/app/src/permissions/executive.py
+++ b/app/src/permissions/executive.py
@@ -5,8 +5,10 @@ Provides Pydantic schemas to define the hierarchical structure of permissions
 for executives within the system and permission paths for specific actions.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from enum import StrEnum
+
+from app.src.permissions.base import PermissionBase
 
 
 ## Permission Paths
@@ -96,7 +98,7 @@ class PermissionPath(StrEnum):
 
 
 ## Permission Schemas
-class CRUDPermission(BaseModel):
+class CRUDPermission(PermissionBase):
     """Generic CRUD permission set — reused by most entities."""
 
     create: bool = Field(description="Allow creation")
@@ -104,7 +106,7 @@ class CRUDPermission(BaseModel):
     delete: bool = Field(description="Allow deletion")
 
 
-class TokenPermission(BaseModel):
+class TokenPermission(PermissionBase):
     """Specialized permissions for token management."""
 
     fetch: bool = Field(description="Allow fetching token details")
@@ -144,13 +146,13 @@ class OperatorPermissions(CRUDPermission):
     token: TokenPermission
 
 
-class DutyPermission(BaseModel):
+class DutyPermission(PermissionBase):
     """Duty related permissions."""
 
     update: bool = Field(description="Allow updating duties")
 
 
-class CreatePermission(BaseModel):
+class CreatePermission(PermissionBase):
     """Single action create permission."""
 
     create: bool = Field(description="Allow creation")
@@ -175,7 +177,7 @@ class CompanyPermissions(CRUDPermission):
     schedule: CRUDPermission
 
 
-class PermissionSchema(BaseModel):
+class PermissionSchema(PermissionBase):
     """Top-level hierarchical permission structure for an ExecutiveRole."""
 
     landmark: LandmarkPermissions

--- a/app/src/permissions/operator.py
+++ b/app/src/permissions/operator.py
@@ -5,8 +5,10 @@ Provides Pydantic schemas to define the hierarchical structure of permissions
 for operators within the system and permission paths for specific actions.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from enum import StrEnum
+
+from app.src.permissions.base import PermissionBase
 
 
 ## Permission Paths
@@ -57,7 +59,7 @@ class PermissionPath(StrEnum):
     DELETE_COMPANY_SCHEDULE = "company.schedule.delete"
 
 
-class CRUDPermission(BaseModel):
+class CRUDPermission(PermissionBase):
     """Generic CRUD permission set — reused by most entities."""
 
     create: bool = Field(description="Allow creation")
@@ -65,20 +67,20 @@ class CRUDPermission(BaseModel):
     delete: bool = Field(description="Allow deletion")
 
 
-class TokenPermission(BaseModel):
+class TokenPermission(PermissionBase):
     """Specialized permissions for token management."""
 
     fetch: bool = Field(description="Allow fetching token details")
     delete: bool = Field(description="Allow deleting token")
 
 
-class DutyPermission(BaseModel):
+class DutyPermission(PermissionBase):
     """Duty related permissions."""
 
     update: bool = Field(description="Allow updating duties")
 
 
-class CreatePermission(BaseModel):
+class CreatePermission(PermissionBase):
     """Single action create permission."""
 
     create: bool = Field(description="Allow creation")
@@ -100,7 +102,7 @@ class ServicePermissions(CRUDPermission):
     statement: CreatePermission
 
 
-class CompanyPermission(BaseModel):
+class CompanyPermission(PermissionBase):
     """Company related permissions."""
 
     update: bool = Field(description="Allow updating company details")
@@ -112,7 +114,7 @@ class CompanyPermission(BaseModel):
     schedule: CRUDPermission
 
 
-class PermissionSchema(BaseModel):
+class PermissionSchema(PermissionBase):
     """Top-level hierarchical permission structure for an OperatorRole."""
 
     company: CompanyPermission

--- a/app/src/permissions/vendor.py
+++ b/app/src/permissions/vendor.py
@@ -5,8 +5,10 @@ Provides Pydantic schemas to define the hierarchical structure of permissions
 for vendors within the system and permission paths for specific actions.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from enum import StrEnum
+
+from app.src.permissions.base import PermissionBase
 
 
 ## Permission Paths
@@ -27,7 +29,7 @@ class PermissionPath(StrEnum):
     DELETE_BUSINESS_VENDOR_TOKEN = "business.vendor.token.delete"
 
 
-class CRUDPermission(BaseModel):
+class CRUDPermission(PermissionBase):
     """Generic CRUD permission set — reused by most entities."""
 
     create: bool = Field(description="Allow creation")
@@ -35,7 +37,7 @@ class CRUDPermission(BaseModel):
     delete: bool = Field(description="Allow deletion")
 
 
-class TokenPermission(BaseModel):
+class TokenPermission(PermissionBase):
     """Specialized permissions for token management."""
 
     fetch: bool = Field(description="Allow fetching token details")
@@ -49,14 +51,14 @@ class VendorPermissions(CRUDPermission):
     token: TokenPermission
 
 
-class BusinessPermission(BaseModel):
+class BusinessPermission(PermissionBase):
     """Business related permissions."""
 
     update: bool = Field(description="Allow updating business details")
     vendor: VendorPermissions
 
 
-class PermissionSchema(BaseModel):
+class PermissionSchema(PermissionBase):
     """Top-level hierarchical permission structure for a VendorRole."""
 
     business: BusinessPermission

--- a/readme.md
+++ b/readme.md
@@ -111,11 +111,8 @@ All database migrations and schema management are handled via **Alembic** and th
 Run the following commands from the project root:
 
 ```bash
-# Create a new migration (revision) from model changes
-python -m app.setup tables revise "added new table"
-
-# Apply migrations (bring DB schema to latest head)
-python -m app.setup tables migrate
+python -m app.setup tables revise "added new table" # Create a new migration (revision) from model changes
+python -m app.setup tables migrate                  # Apply migrations (bring DB schema to latest head)
 
 # Reset the database (drop + recreate schema)
 # Note: Reinstall PostGIS extension when you do so
@@ -125,25 +122,15 @@ python -m app.setup tables reset
 python -m app.setup tables downgrade
 python -m app.setup tables downgrade -2
 
-# Create all tables directly (without migrations)
-# Note: Use with caution (not for production)
-python -m app.setup tables create
+# Note: Use with caution (not for production/regular use)
+python -m app.setup tables create                   # Create all tables directly (without migrations)
+python -m app.setup tables delete                   # Delete all tables (without migrations)
+python -m app.setup tables init                     # Initialize the database with default data
 
-# Delete all tables (without migrations)
-# Note: Use with caution (not for production)
-python -m app.setup tables delete
+python -m app.setup buckets create                  # Create all MinIO buckets (defined in app/src/buckets.py)
+python -m app.setup buckets delete                  # Delete all MinIO buckets
 
-# Initialize the database with default data
-python -m app.setup tables init
-
-# Create all MinIO buckets (defined in app/src/buckets.py)
-python -m app.setup buckets create
-
-# Delete all MinIO buckets
-python -m app.setup buckets delete
-
-# To run the tests (Make sure the server is running)
-python -m tests.setup test api
+python -m tests.setup test api                      # To run the tests (Make sure the server is running)
 ```
 
 


### PR DESCRIPTION


### **Summary of Changes**
- Replaced manually hardcoded permission template dictionaries with schema-generated defaults using all_granted() and all_denied()
- Removed duplicated permission structures across executive, operator, and vendor permission templates
- Improved maintainability by centralizing default permission generation within permission schemas
- Ensured newly added permission fields are automatically reflected in generated default templates

### **How to Test / Verify**
- Run application setup/init flow and verify admin and guest roles are created successfully
- Print and verify generated permission dictionaries from:
     -  PermissionSchemaEX.all_granted().model_dump()
     - PermissionSchemaEX.all_denied().model_dump()
    -  PermissionSchemaOP.all_granted().model_dump()
    - PermissionSchemaOP.all_denied().model_dump()
    - PermissionSchemaVN.all_granted().model_dump()
    - PermissionSchemaVN.all_denied().model_dump()
- Confirm generated permission structures match the previous hardcoded permission templates
- Run existing permission-related tests and verify behavior remains unchanged


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
