### PR TITLE
Expose min io and open observe UI to the outside world

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import text
@@ -35,7 +36,9 @@ from app.src.db import (
 
 
 def _alembic_cfg() -> Config:
-    alembic_cfg = Config("app/alembic.ini")
+    current_dir = os.path.dirname(__file__)
+    alembic_ini = os.path.join(current_dir, "alembic.ini")
+    alembic_cfg = Config(alembic_ini)
     alembic_cfg.set_main_option("sqlalchemy.url", get_db_url())
     return alembic_cfg
 

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -28,6 +28,44 @@ patches:
       - op: replace
         path: /spec/rules/0/host
         value: dev-api.entebus.com
+      - op: add
+        path: /spec/tls/1
+        value:
+          hosts:
+            - dev-minio.entebus.com
+          secretName: cloudflare-origin-cert
+      - op: add
+        path: /spec/tls/2
+        value:
+          hosts:
+            - dev-openobserve.entebus.com
+          secretName: cloudflare-origin-cert
+      - op: add
+        path: /spec/rules/1
+        value:
+          host: dev-minio.entebus.com
+          http:
+            paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: minio
+                    port:
+                      number: 9001
+      - op: add
+        path: /spec/rules/2
+        value:
+          host: dev-openobserve.entebus.com
+          http:
+            paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: openobserve
+                    port:
+                      number: 5080
 
   - target:
       kind: Deployment

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -25,21 +25,15 @@ patches:
       - op: replace
         path: /spec/tls/0/hosts/0
         value: dev-api.entebus.com
+      - op: add
+        path: /spec/tls/0/hosts/1
+        value: dev-minio.entebus.com
+      - op: add
+        path: /spec/tls/0/hosts/2
+        value: dev-openobserve.entebus.com
       - op: replace
         path: /spec/rules/0/host
         value: dev-api.entebus.com
-      - op: add
-        path: /spec/tls/1
-        value:
-          hosts:
-            - dev-minio.entebus.com
-          secretName: cloudflare-origin-cert
-      - op: add
-        path: /spec/tls/2
-        value:
-          hosts:
-            - dev-openobserve.entebus.com
-          secretName: cloudflare-origin-cert
       - op: add
         path: /spec/rules/1
         value:

--- a/k8s/overlays/dev/minio.yaml
+++ b/k8s/overlays/dev/minio.yaml
@@ -39,9 +39,8 @@ spec:
               subPath: minio-files
       volumes:
         - name: minio-data
-          hostPath:
-            path: /mnt/minio-dev-data
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: minio-pvc
 ---
 apiVersion: v1
 kind: Service
@@ -58,3 +57,15 @@ spec:
     - name: console
       port: 9001
       targetPort: 9001
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pvc
+  namespace: entebus
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/overlays/dev/openobserve.yaml
+++ b/k8s/overlays/dev/openobserve.yaml
@@ -51,9 +51,8 @@ spec:
               subPath: zo-data
       volumes:
         - name: openobserve-data
-          hostPath:
-            path: /mnt/openobserve-dev-data
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: openobserve-pvc
 ---
 apiVersion: v1
 kind: Service
@@ -67,3 +66,15 @@ spec:
     - name: http
       port: 5080
       targetPort: 5080
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openobserve-pvc
+  namespace: entebus
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/overlays/dev/openobserve.yaml
+++ b/k8s/overlays/dev/openobserve.yaml
@@ -27,7 +27,6 @@ spec:
           volumeMounts:
             - name: openobserve-data
               mountPath: /data
-              subPath: zo-data
       containers:
         - name: openobserve
           image: public.ecr.aws/zinclabs/openobserve:latest
@@ -49,7 +48,6 @@ spec:
           volumeMounts:
             - name: openobserve-data
               mountPath: /data
-              subPath: zo-data
       volumes:
         - name: openobserve-data
           persistentVolumeClaim:

--- a/k8s/overlays/dev/openobserve.yaml
+++ b/k8s/overlays/dev/openobserve.yaml
@@ -27,6 +27,7 @@ spec:
           volumeMounts:
             - name: openobserve-data
               mountPath: /data
+              subPath: zo-data
       containers:
         - name: openobserve
           image: public.ecr.aws/zinclabs/openobserve:latest

--- a/k8s/overlays/dev/postgis.yaml
+++ b/k8s/overlays/dev/postgis.yaml
@@ -41,9 +41,8 @@ spec:
               subPath: pgdata
       volumes:
         - name: postgres-data
-          hostPath:
-            path: /mnt/postgres-dev-data
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: postgis-pvc
 ---
 apiVersion: v1
 kind: Service
@@ -57,3 +56,15 @@ spec:
     - name: postgres
       port: 5432
       targetPort: 5432
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgis-pvc
+  namespace: entebus
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/readme.md
+++ b/k8s/readme.md
@@ -116,16 +116,16 @@ In Cloudflare dashboard:
 
 ### 2 Create Kubernetes TLS secret
 
-From the project root (or directory containing the certificate files):
+From the project root (or directory containing the certificate files), run **one** of the following commands:
 
 ```bash
-# Create TLS secret in the entebus namespace
+# First-time creation of the TLS secret in the entebus namespace
 kubectl create secret tls cloudflare-origin-cert \
 	--namespace entebus \
 	--cert=origin.crt \
 	--key=origin.key
 
-# Replace existing secret if it already exists (idempotent)
+# If the secret already exists, update/apply it idempotently instead
 kubectl create secret tls cloudflare-origin-cert \
   --cert=origin.crt --key=origin.key -n entebus \
   --dry-run=client -o yaml | kubectl apply -f -

--- a/k8s/readme.md
+++ b/k8s/readme.md
@@ -142,8 +142,8 @@ kubectl get secret cloudflare-origin-cert -n entebus
 The ingress already references:
 
 - Secret name: `cloudflare-origin-cert`
-- TLS host in base: `api.entebus.com, minio.entebus.com, openobserve.entebus.com`
-- TLS host in dev overlay: `dev-api.entebus.com, dev-minio.entebus.com, dev-openobserve.entebus.com`
+- TLS host in base: `api.entebus.com`
+- TLS hosts in overlays may differ; verify the rendered ingress manifest for your target overlay
 
 Confirm final ingress manifest:
 

--- a/k8s/readme.md
+++ b/k8s/readme.md
@@ -23,6 +23,9 @@ This guide explains how to deploy **Entebus Server** on Kubernetes using Kustomi
 - Uses app image tag: `develop`
 - Rewrites ingress host to: `dev-api.entebus.com`
 - Changes namespace label `environment` to `dev`
+- Rewrites ingress host to: `dev-api.entebus.com` and adds hosts for developer UIs:
+   - `dev-minio.entebus.com` (MinIO console)
+   - `dev-openobserve.entebus.com` (OpenObserve UI)
 
 ### `overlays/prod`
 
@@ -103,8 +106,8 @@ In Cloudflare dashboard:
 1. Go to **SSL/TLS → Origin Server**
 2. Click **Create Certificate**
 3. Choose:
-	 - **Private Key Type:** RSA (2048)
-	 - **Hostnames:** add all required domains (example: `api.entebus.com`, `dev-api.entebus.com`)
+ 	 - **Private Key Type:** RSA (2048)
+ 	 - **Hostnames:** add all required domains (example: `api.entebus.com`, `dev-api.entebus.com`, `dev-minio.entebus.com`, `dev-openobserve.entebus.com`, `minio.entebus.com`, `openobserve.entebus.com`)
 	 - **Validity:** 15 years
 4. Download/save files in PEM format:
 	 - `origin.crt`

--- a/k8s/readme.md
+++ b/k8s/readme.md
@@ -23,10 +23,10 @@ This guide explains how to deploy **Entebus Server** on Kubernetes using Kustomi
 - Uses app image tag: `develop`
 - Rewrites ingress host to: `dev-api.entebus.com`
 - Changes namespace label `environment` to `dev`
-- Rewrites ingress host to: 
-	-`dev-api.entebus.com` (API endpoint)
-   - `dev-minio.entebus.com` (MinIO console)
-   - `dev-openobserve.entebus.com` (OpenObserve UI)
+- Rewrites ingress host to:
+  - `dev-api.entebus.com` (API endpoint)
+  - `dev-minio.entebus.com` (MinIO console)
+  - `dev-openobserve.entebus.com` (OpenObserve UI)
 
 ### `overlays/prod`
 

--- a/k8s/readme.md
+++ b/k8s/readme.md
@@ -23,7 +23,8 @@ This guide explains how to deploy **Entebus Server** on Kubernetes using Kustomi
 - Uses app image tag: `develop`
 - Rewrites ingress host to: `dev-api.entebus.com`
 - Changes namespace label `environment` to `dev`
-- Rewrites ingress host to: `dev-api.entebus.com` and adds hosts for developer UIs:
+- Rewrites ingress host to: 
+	-`dev-api.entebus.com` (API endpoint)
    - `dev-minio.entebus.com` (MinIO console)
    - `dev-openobserve.entebus.com` (OpenObserve UI)
 

--- a/k8s/readme.md
+++ b/k8s/readme.md
@@ -118,10 +118,16 @@ In Cloudflare dashboard:
 From the project root (or directory containing the certificate files):
 
 ```bash
+# Create TLS secret in the entebus namespace
 kubectl create secret tls cloudflare-origin-cert \
 	--namespace entebus \
 	--cert=origin.crt \
 	--key=origin.key
+
+# Replace existing secret if it already exists (idempotent)
+kubectl create secret tls cloudflare-origin-cert \
+  --cert=origin.crt --key=origin.key -n entebus \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 
 Verify secret:
@@ -135,8 +141,8 @@ kubectl get secret cloudflare-origin-cert -n entebus
 The ingress already references:
 
 - Secret name: `cloudflare-origin-cert`
-- TLS host in base: `api.entebus.com`
-- TLS host in dev overlay: `dev-api.entebus.com` (patched)
+- TLS host in base: `api.entebus.com, minio.entebus.com, openobserve.entebus.com`
+- TLS host in dev overlay: `dev-api.entebus.com, dev-minio.entebus.com, dev-openobserve.entebus.com`
 
 Confirm final ingress manifest:
 


### PR DESCRIPTION
### **Summary of Changes**
- Added ingress rules and TLS configuration for MinIO and OpenObserve developer UIs
- Exposed:
  - dev-minio.entebus.com
  - dev-openobserve.entebus.com
- Added PersistentVolumeClaims for MinIO, OpenObserve, and PostGIS
- Updated deployments to use persistent storage volume mounts
- Updated README with developer UI access and TLS secret setup instructions
### **How to Test / Verify**
- Verify MinIO and OpenObserve are accessible
- Make sure all services are working correctly


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
