### PR TITLE
Add service id exclude filter support service assignment endpoint

### DIFF
--- a/app/api/service_assignment.py
+++ b/app/api/service_assignment.py
@@ -95,6 +95,7 @@ class QueryParamsForOP(PaginationFilter, IDFilter, CreatedOnFilter, UpdatedOnFil
     """Query parameters for operators."""
 
     service_id: int | None = Field(Query(default=None))
+    service_id_excluding: List[int] | None = Field(Query(default=None))
     operator_id: int | None = Field(Query(default=None))
     order_by: OrderBy = Field(Query(default=OrderBy.ID, description=enum_str(OrderBy)))
     order_in: OrderIn = Field(
@@ -178,6 +179,10 @@ def search_service_assignments(
         query = query.filter(ServiceAssignment.company_id == query_params.company_id)
     if query_params.service_id is not None:
         query = query.filter(ServiceAssignment.service_id == query_params.service_id)
+    if query_params.service_id_excluding:
+        query = query.filter(
+            ServiceAssignment.service_id.notin_(query_params.service_id_excluding)
+        )
     if query_params.operator_id is not None:
         query = query.filter(ServiceAssignment.operator_id == query_params.operator_id)
 


### PR DESCRIPTION


### **Summary of Changes**
- Added service_id_excluding query parameter support to the /Service/Assignment endpoint
- Implemented filtering to exclude specified service IDs from the response
- Aligned exclude filter behavior with the existing /Service endpoint implementation

### **How to Test / Verify**
- Call /Service/Assignment with service_id_exclude
- Verify excluded service IDs are not returned in the response
- Verify existing filters and pagination continue to work correctly


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
