### PR TITLE
Add standardized templates for issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: "Bug report"
+about: "Create a report to help us improve Entebus."
+title: "[BUG] "
+labels: ["bug"]
+assignees: []
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. 
+2. 
+3. 
+
+**Expected behavior**
+What you expected to happen.
+
+**Logs / Tracebacks**
+If applicable, paste any relevant log output or traceback.
+
+**Environment**
+- Entebus version (from pyproject or setup.py):
+- Python version:
+- OS:
+- Installed dependencies (requirements.txt / pip freeze):
+
+**Additional context**
+Add any other context about the problem here. A minimal, reproducible example is very helpful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Security policy"
+    url: "/SECURITY.md"
+    about: "Report security vulnerabilities privately."

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: "Feature request"
+about: "Suggest an improvement or a new feature."
+title: "[FEATURE] "
+labels: ["enhancement"]
+assignees: []
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+If applicable, describe other approaches you tried or considered.
+
+**Additional context**
+Add any other context or mockups that would help evaluate the request.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,21 @@
+---
+name: "Question / Help"
+about: "General question, usage help, or support request."
+title: "[QUESTION] "
+labels: ["question"]
+assignees: []
+---
+
+**What is your question?**
+Be as specific as possible.
+
+**What did you try so far?**
+Describe steps you've already taken to solve the problem.
+
+**Environment**
+- Entebus version:
+- Python version:
+- OS:
+
+**Additional context**
+Provide any logs, config snippets, or minimal examples that help reproduce the issue.

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,16 @@
+---
+name: "Security vulnerability"
+about: "Report a security vulnerability privately. Do NOT file public issues for sensitive reports."
+title: "Security report: "
+labels: ["security"]
+assignees: []
+---
+
+Security vulnerabilities should not be disclosed in public issues.
+
+Please consult the repository SECURITY.md for secure reporting instructions. If a security policy is not available, contact the maintainers privately with details necessary to triage and remediate the issue. Avoid posting exploit code or full details in public.
+
+If you must provide a public report (non-sensitive), include:
+- A high-level description of the issue
+- Affected versions
+- Steps to reproduce (non-exploitable summary)


### PR DESCRIPTION


### **Summary of Changes**
 - Added GitHub issue templates for bug reports, feature requests, questions/help, and security vulnerability reporting.
- Added repository issue template configuration.
- Disabled blank issue creation.
- Added security reporting guidance in issue configuration.
### **How to Test / Verify**
- Navigate to the repository Issues tab.
- Verify the new issue templates are available.
- Verify blank issue creation is disabled.
- Verify the security reporting link/guidance is visible.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
