### PR TITLE
Remove redundant company or bussiness id from image upload apis

### DIFF
--- a/app/api/operator_image.py
+++ b/app/api/operator_image.py
@@ -99,7 +99,6 @@ class ImageUploadForm(BaseModel):
 class CreateFormForEX(ImageUploadForm):
     """Form data for creating a new operator image for an executive."""
 
-    company_id: int = Field(Form())
     operator_id: int = Field(Form())
 
 
@@ -158,21 +157,24 @@ class ImageQueryParams(BaseModel):
 
 
 # Functions
-def create_image(session: Session, form_param: CreateForm, file_bytes: bytes) -> dict:
+def create_image(
+    session: Session, form_param: CreateForm, operator: Operator, file_bytes: bytes
+) -> dict:
     """
     Creates a new operator image record in the database.
 
     Args:
         session (Session): SQLAlchemy database session.
         form_param (CreateForm): Form data for creating an operator image.
+        operator (Operator): The operator instance associated with the image.
         file_bytes (bytes): The image file bytes.
 
     Returns:
         dict: The created operator image data.
     """
     operator_image = OperatorImage(
-        company_id=form_param.company_id,
-        operator_id=form_param.operator_id,
+        company_id=operator.company_id,
+        operator_id=operator.id,
         file_name=form_param.file.filename,
         file_type=form_param.file.content_type,
         file_size=len(file_bytes),
@@ -304,10 +306,6 @@ def download_image(
             exceptions.NoPermission(),
             exceptions.InvalidImageFile(),
             exceptions.UnknownValue(OperatorImage.operator_id),
-            exceptions.UnknownValue(OperatorImage.company_id),
-            exceptions.InvalidAssociation(
-                OperatorImage.operator_id, OperatorImage.company_id
-            ),
         ]
     ),
     description=(
@@ -329,20 +327,15 @@ async def upload_operator_image_for_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR)
 
-        validate_id(session, Company, form_param.company_id, OperatorImage.company_id)
         operator = validate_id(
             session, Operator, form_param.operator_id, OperatorImage.operator_id
         )
-        if operator.company_id != form_param.company_id:
-            raise exceptions.InvalidAssociation(
-                OperatorImage.operator_id, OperatorImage.company_id
-            )
 
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
 
         operator_image_data = create_image(
-            session, CreateForm(**form_param.model_dump()), file_bytes
+            session, CreateForm(**form_param.model_dump()), operator, file_bytes
         )
         log_event(token, request_info, operator_image_data)
         return operator_image_data
@@ -494,7 +487,7 @@ async def upload_operator_image_for_operator(
             roles = get_operator_roles(session, token)
             verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_OPERATOR)
 
-        validate_id(
+        operator = validate_id(
             session,
             Operator,
             form_param.operator_id,
@@ -506,7 +499,8 @@ async def upload_operator_image_for_operator(
 
         operator_image_data = create_image(
             session,
-            CreateForm(**form_param.model_dump(), company_id=token.company_id),
+            CreateForm(**form_param.model_dump()),
+            operator,
             file_bytes,
         )
         log_event(token, request_info, operator_image_data)

--- a/app/api/vehicle_image.py
+++ b/app/api/vehicle_image.py
@@ -106,7 +106,7 @@ class CreateFormForOP(ImageUploadForm):
 class CreateFormForEX(CreateFormForOP):
     """Form data for creating a new vehicle image for an executive."""
 
-    company_id: int = Field(Form())
+    pass
 
 
 class CreateForm(CreateFormForEX):
@@ -164,21 +164,24 @@ class ImageQueryParams(BaseModel):
 
 
 # Functions
-def create_image(session: Session, form_param: CreateForm, file_bytes: bytes) -> dict:
+def create_image(
+    session: Session, form_param: CreateForm, vehicle: Vehicle, file_bytes: bytes
+) -> dict:
     """
     Creates a new vehicle image record in the database.
 
     Args:
         session (Session): SQLAlchemy database session.
         form_param (CreateForm): Form data for creating a vehicle image.
+        vehicle (Vehicle): The vehicle instance associated with the image.
         file_bytes (bytes): The image file bytes.
 
     Returns:
         dict: The created vehicle image data.
     """
     vehicle_image = VehicleImage(
-        company_id=form_param.company_id,
-        vehicle_id=form_param.vehicle_id,
+        company_id=vehicle.company_id,
+        vehicle_id=vehicle.id,
         file_name=form_param.file.filename,
         file_type=form_param.file.content_type,
         file_size=len(file_bytes),
@@ -310,10 +313,6 @@ def download_image(
             exceptions.NoPermission(),
             exceptions.InvalidImageFile(),
             exceptions.UnknownValue(VehicleImage.vehicle_id),
-            exceptions.UnknownValue(VehicleImage.company_id),
-            exceptions.InvalidAssociation(
-                VehicleImage.vehicle_id, VehicleImage.company_id
-            ),
         ]
     ),
     description=(
@@ -335,20 +334,15 @@ async def upload_vehicle_image_for_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.UPDATE_COMPANY_VEHICLE)
 
-        validate_id(session, Company, form_param.company_id, VehicleImage.company_id)
         vehicle = validate_id(
             session, Vehicle, form_param.vehicle_id, VehicleImage.vehicle_id
         )
-        if vehicle.company_id != form_param.company_id:
-            raise exceptions.InvalidAssociation(
-                VehicleImage.vehicle_id, VehicleImage.company_id
-            )
 
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
 
         vehicle_image_data = create_image(
-            session, CreateForm(**form_param.model_dump()), file_bytes
+            session, CreateForm(**form_param.model_dump()), vehicle, file_bytes
         )
         log_event(token, request_info, vehicle_image_data)
         return vehicle_image_data
@@ -494,7 +488,7 @@ async def upload_vehicle_image_for_operator(
         roles = get_operator_roles(session, token)
         verify_permission(roles, OperatorPermissionPath.UPDATE_COMPANY_VEHICLE)
 
-        validate_id(
+        vehicle = validate_id(
             session,
             Vehicle,
             form_param.vehicle_id,
@@ -506,7 +500,8 @@ async def upload_vehicle_image_for_operator(
 
         vehicle_image_data = create_image(
             session,
-            CreateForm(**form_param.model_dump(), company_id=token.company_id),
+            CreateForm(**form_param.model_dump()),
+            vehicle,
             file_bytes,
         )
         log_event(token, request_info, vehicle_image_data)

--- a/app/api/vendor_image.py
+++ b/app/api/vendor_image.py
@@ -99,7 +99,6 @@ class ImageUploadForm(BaseModel):
 class CreateFormForEX(ImageUploadForm):
     """Form data for creating a new vendor image for an executive."""
 
-    business_id: int = Field(Form())
     vendor_id: int = Field(Form())
 
 
@@ -158,21 +157,24 @@ class ImageQueryParams(BaseModel):
 
 
 # Functions
-def create_image(session: Session, form_param: CreateForm, file_bytes: bytes) -> dict:
+def create_image(
+    session: Session, form_param: CreateForm, vendor: Vendor, file_bytes: bytes
+) -> dict:
     """
     Creates a new vendor image record in the database.
 
     Args:
         session (Session): SQLAlchemy database session.
         form_param (CreateForm): Form data for creating a vendor image.
+        vendor (Vendor): The vendor instance associated with the image.
         file_bytes (bytes): The image file bytes.
 
     Returns:
         dict: The created vendor image data.
     """
     vendor_image = VendorImage(
-        business_id=form_param.business_id,
-        vendor_id=form_param.vendor_id,
+        business_id=vendor.business_id,
+        vendor_id=vendor.id,
         file_name=form_param.file.filename,
         file_type=form_param.file.content_type,
         file_size=len(file_bytes),
@@ -304,10 +306,6 @@ def download_image(
             exceptions.NoPermission(),
             exceptions.InvalidImageFile(),
             exceptions.UnknownValue(VendorImage.vendor_id),
-            exceptions.UnknownValue(VendorImage.business_id),
-            exceptions.InvalidAssociation(
-                VendorImage.vendor_id, VendorImage.business_id
-            ),
         ]
     ),
     description=(
@@ -329,20 +327,15 @@ async def upload_vendor_image_for_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.UPDATE_BUSINESS_VENDOR)
 
-        validate_id(session, Business, form_param.business_id, VendorImage.business_id)
         vendor = validate_id(
             session, Vendor, form_param.vendor_id, VendorImage.vendor_id
         )
-        if vendor.business_id != form_param.business_id:
-            raise exceptions.InvalidAssociation(
-                VendorImage.vendor_id, VendorImage.business_id
-            )
 
         file_bytes = await form_param.file.read()
         validate_image(file_bytes, form_param.file.filename)
 
         vendor_image_data = create_image(
-            session, CreateForm(**form_param.model_dump()), file_bytes
+            session, CreateForm(**form_param.model_dump()), vendor, file_bytes
         )
         log_event(token, request_info, vendor_image_data)
         return vendor_image_data
@@ -490,7 +483,7 @@ async def upload_vendor_image_for_vendor(
             roles = get_vendor_roles(session, token)
             verify_permission(roles, VendorPermissionPath.UPDATE_BUSINESS_VENDOR)
 
-        validate_id(
+        vendor = validate_id(
             session,
             Vendor,
             form_param.vendor_id,
@@ -502,7 +495,8 @@ async def upload_vendor_image_for_vendor(
 
         vendor_image_data = create_image(
             session,
-            CreateForm(**form_param.model_dump(), business_id=token.business_id),
+            CreateForm(**form_param.model_dump()),
+            vendor,
             file_bytes,
         )
         log_event(token, request_info, vendor_image_data)


### PR DESCRIPTION
### **Summary of Changes**
- Removed redundant company_id / business_id from image upload forms.
- Derived company/business association from validated entities.
- Updated image creation flow for vehicle, operator, and vendor images.

### **How to Test / Verify**
- Upload vehicle, operator, and vendor images without passing company_id / business_id.
- Verify images are created successfully.
- Verify invalid cross-company/business uploads are rejected

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A

### **Reviewer Notes**
N/A
