### PR TITLE
Fix public endpoint query adaption error in current pattern

### DIFF
--- a/app/api/route.py
+++ b/app/api/route.py
@@ -39,7 +39,6 @@ from app.src.functions import (
     get_executive_roles,
     get_operator_roles,
     fuse_exception_responses,
-    resolve_model_defaults,
     update_if_changed,
     apply_created_on_filters,
     apply_updated_on_filters,

--- a/app/api/service.py
+++ b/app/api/service.py
@@ -42,6 +42,7 @@ from app.src.db import (
 from app.src import exceptions
 from app.src.functions import (
     apply_id_filters,
+    resolve_model_defaults,
     get_request_info,
     get_executive_roles,
     get_operator_roles,
@@ -1744,14 +1745,10 @@ async def fetch_service_public(query_params: QueryParamsForPU = Depends()):
     try:
         session = SessionLocal()
 
-        return search_service(
-            session,
-            QueryParams(
-                **query_params.model_dump(),
-                company_id=None,
-                id_excluding=None,
-            ),
+        query_params = resolve_model_defaults(
+            QueryParams, **query_params.model_dump()
         )
+        return search_service(session, query_params)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/service.py
+++ b/app/api/service.py
@@ -1745,9 +1745,7 @@ async def fetch_service_public(query_params: QueryParamsForPU = Depends()):
     try:
         session = SessionLocal()
 
-        query_params = resolve_model_defaults(
-            QueryParams, **query_params.model_dump()
-        )
+        query_params = resolve_model_defaults(QueryParams, **query_params.model_dump())
         return search_service(session, query_params)
     except Exception as e:
         exceptions.handle(e)


### PR DESCRIPTION


### **Summary of Changes**
-  Fixed the public endpoint query adaptation error by using resolve_model_defaults before constructing QueryParams.
- Updated the public endpoint flow to follow the existing query parameter handling pattern.

### **How to Test / Verify**
- Run the server and ensure it starts successfully.
- Test affected public endpoints from Swagger
- Verify the can't adapt type 'Query' error no longer occurs.
- Confirm existing endpoint behavior still works correctly.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A

### **Reviewer Notes**
N/A
