### PR TITLE
Enforce operator account limit per company (100)

### DIFF
--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -335,7 +335,11 @@ def delete_operator(session: Session, operator: Operator) -> dict:
     response_model=OperatorSchema,
     status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(
-        [exceptions.InvalidToken(), exceptions.NoPermission()]
+        [
+            exceptions.InvalidToken(),
+            exceptions.NoPermission(),
+            exceptions.LimitExceeded(Operator),
+        ]
     ),
     description=(
         f"""

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -517,7 +517,11 @@ async def delete_account_executive(
     response_model=OperatorSchema,
     status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(
-        [exceptions.InvalidToken(), exceptions.NoPermission()]
+        [
+            exceptions.InvalidToken(),
+            exceptions.NoPermission(),
+            exceptions.LimitExceeded(Operator),
+        ]
     ),
     description=(
         f"""

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -184,8 +184,14 @@ def validate_operator_limit(
 ):
     """
     Validate maximum operator count per company.
-    """
 
+    Args:
+        session (Session): SQLAlchemy database session.
+        company_id (int): ID of the company to validate.
+
+    Raises:
+        LimitExceeded: If the company has reached MAX_OPERATORS_PER_COMPANY limit.
+    """
     operator_count = (
         session.query(Operator)
         .filter(
@@ -511,12 +517,13 @@ async def delete_account_executive(
         [exceptions.InvalidToken(), exceptions.NoPermission()]
     ),
     description=(
-        """
+        f"""
             **Creates a new operator account.**    
             - Operator must have a valid access token.    
             - Logged-in operator must have `company.operator.create` permission.    
             - Duplicate usernames are not allowed.    
-            - By default the user is created in active status.    
+            - By default the user is created in active status.   
+            - Maximum `{MAX_OPERATORS_PER_COMPANY}` operators are allowed per company. 
         """
     ),
 )

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -367,7 +367,6 @@ async def create_account_executive(
             session,
             form_param.company_id,
         )
-
         operator = Operator(
             company_id=form_param.company_id,
             username=form_param.username,
@@ -529,7 +528,7 @@ async def delete_account_executive(
             - Operator must have a valid access token.    
             - Logged-in operator must have `company.operator.create` permission.    
             - Duplicate usernames are not allowed.    
-            - By default the user is created in active status.    
+            - By default, the user is created with active status.    
             - Maximum `{MAX_OPERATORS_PER_COMPANY}` operators are allowed per company.    
         """
     ),
@@ -544,6 +543,7 @@ async def create_account_operator(
         token = verify_token(session, OperatorToken, access_token.credentials)
         roles = get_operator_roles(session, token)
         verify_permission(roles, OperatorPermissionPath.CREATE_COMPANY_OPERATOR)
+
         validate_operator_limit(
             session,
             token.company_id,

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -199,7 +199,6 @@ def validate_operator_limit(
         )
         .count()
     )
-
     if operator_count >= MAX_OPERATORS_PER_COMPANY:
         raise exceptions.LimitExceeded(Operator)
 
@@ -344,8 +343,8 @@ def delete_operator(session: Session, operator: Operator) -> dict:
             - Executive must have a valid access token.    
             - Logged-in executive must have `company.operator.create` permission.    
             - Duplicate usernames are not allowed.    
-            - By default, the user is created with active status.     
-            - Maximum `{MAX_OPERATORS_PER_COMPANY}` operators are allowed per company.  
+            - By default, the user is created with active status.    
+            - Maximum `{MAX_OPERATORS_PER_COMPANY}` operators are allowed per company.    
         """
     ),
 )

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -55,6 +55,7 @@ from app.src.functions import (
     apply_status_filters,
     apply_type_filters,
 )
+from app.src.constants import MAX_OPERATORS_PER_COMPANY
 
 route_executive = APIRouter()
 route_operator = APIRouter()
@@ -312,12 +313,13 @@ def delete_operator(session: Session, operator: Operator) -> dict:
         [exceptions.InvalidToken(), exceptions.NoPermission()]
     ),
     description=(
-        """
+        f"""
             **Creates a new operator account.**    
             - Executive must have a valid access token.    
             - Logged-in executive must have `company.operator.create` permission.    
             - Duplicate usernames are not allowed.    
-            - By default the user is created in active status.    
+            - By default the user is created in active status. 
+            - Maximum `{MAX_OPERATORS_PER_COMPANY}` operators allowed per company   
         """
     ),
 )
@@ -331,6 +333,17 @@ async def create_account_executive(
         token = verify_token(session, ExecutiveToken, access_token)
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.CREATE_COMPANY_OPERATOR)
+
+        operator_count = (
+            session.query(Operator)
+            .filter(
+                Operator.company_id == form_param.company_id,
+            )
+            .count()
+        )
+
+        if operator_count >= MAX_OPERATORS_PER_COMPANY:
+            raise exceptions.LimitExceeded(Operator)
 
         operator = Operator(
             company_id=form_param.company_id,

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -178,6 +178,26 @@ class QueryParams(QueryParamsForEX):
 
 
 ## Functions
+def validate_operator_limit(
+    session: Session,
+    company_id: int,
+):
+    """
+    Validate maximum operator count per company.
+    """
+
+    operator_count = (
+        session.query(Operator)
+        .filter(
+            Operator.company_id == company_id,
+        )
+        .count()
+    )
+
+    if operator_count >= MAX_OPERATORS_PER_COMPANY:
+        raise exceptions.LimitExceeded(Operator)
+
+
 def update_operator(
     session: Session, operator: Operator, form_param: UpdateForm
 ) -> Tuple[bool, dict]:
@@ -318,8 +338,8 @@ def delete_operator(session: Session, operator: Operator) -> dict:
             - Executive must have a valid access token.    
             - Logged-in executive must have `company.operator.create` permission.    
             - Duplicate usernames are not allowed.    
-            - By default the user is created in active status. 
-            - Maximum `{MAX_OPERATORS_PER_COMPANY}` operators allowed per company   
+            - By default, the user is created with active status.     
+            - Maximum `{MAX_OPERATORS_PER_COMPANY}` operators are allowed per company.  
         """
     ),
 )
@@ -334,16 +354,10 @@ async def create_account_executive(
         roles = get_executive_roles(session, token)
         verify_permission(roles, ExecutivePermissionPath.CREATE_COMPANY_OPERATOR)
 
-        operator_count = (
-            session.query(Operator)
-            .filter(
-                Operator.company_id == form_param.company_id,
-            )
-            .count()
+        validate_operator_limit(
+            session,
+            form_param.company_id,
         )
-
-        if operator_count >= MAX_OPERATORS_PER_COMPANY:
-            raise exceptions.LimitExceeded(Operator)
 
         operator = Operator(
             company_id=form_param.company_id,
@@ -516,7 +530,10 @@ async def create_account_operator(
         token = verify_token(session, OperatorToken, access_token.credentials)
         roles = get_operator_roles(session, token)
         verify_permission(roles, OperatorPermissionPath.CREATE_COMPANY_OPERATOR)
-
+        validate_operator_limit(
+            session,
+            token.company_id,
+        )
         operator = Operator(
             company_id=token.company_id,
             username=form_param.username,

--- a/app/api/operator_account.py
+++ b/app/api/operator_account.py
@@ -521,8 +521,8 @@ async def delete_account_executive(
             - Operator must have a valid access token.    
             - Logged-in operator must have `company.operator.create` permission.    
             - Duplicate usernames are not allowed.    
-            - By default the user is created in active status.   
-            - Maximum `{MAX_OPERATORS_PER_COMPANY}` operators are allowed per company. 
+            - By default the user is created in active status.    
+            - Maximum `{MAX_OPERATORS_PER_COMPANY}` operators are allowed per company.    
         """
     ),
 )

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -63,7 +63,7 @@ MINIO_PASSWORD = environ.get("MINIO_PASSWORD", "password")
 # ---------------------------------------------------------------------------
 MAX_EXECUTIVE_TOKENS = 5  # Maximum tokens per executive
 MAX_OPERATOR_TOKENS = 5  # Maximum tokens per operator
-MAX_OPERATORS_PER_COMPANY = 100 # Maximum operator per company
+MAX_OPERATORS_PER_COMPANY = 100  # Maximum operator per company
 MAX_VENDOR_TOKENS = 1  # Maximum tokens per vendor
 MAX_REFRESH_TOKEN_VALIDITY = (
     7 * 24 * 60 * 60

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -63,6 +63,7 @@ MINIO_PASSWORD = environ.get("MINIO_PASSWORD", "password")
 # ---------------------------------------------------------------------------
 MAX_EXECUTIVE_TOKENS = 5  # Maximum tokens per executive
 MAX_OPERATOR_TOKENS = 5  # Maximum tokens per operator
+MAX_OPERATORS_PER_COMPANY = 100 # Maximum operator per company
 MAX_VENDOR_TOKENS = 1  # Maximum tokens per vendor
 MAX_REFRESH_TOKEN_VALIDITY = (
     7 * 24 * 60 * 60

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -63,7 +63,7 @@ MINIO_PASSWORD = environ.get("MINIO_PASSWORD", "password")
 # ---------------------------------------------------------------------------
 MAX_EXECUTIVE_TOKENS = 5  # Maximum tokens per executive
 MAX_OPERATOR_TOKENS = 5  # Maximum tokens per operator
-MAX_OPERATORS_PER_COMPANY = 100  # Maximum operator per company
+MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company
 MAX_VENDOR_TOKENS = 1  # Maximum tokens per vendor
 MAX_REFRESH_TOKEN_VALIDITY = (
     7 * 24 * 60 * 60


### PR DESCRIPTION
### **Summary of Changes**
- Added validation to enforce maximum of 100 operator accounts per company.
- Added server-side check before operator creation to prevent limit violation.
- Reused existing LimitExceeded exception for consistent error handling.
- Ensured enforcement at application level without database schema changes.
### **How to Test / Verify**
- Create operator accounts for a company using the API.
- Ensure creation works normally until the limit is reached.
- Verify that once the company reaches (limit) operator accounts, further creation requests are blocked.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
