### PR TITLE
Fix old develop container clean up logic

### DIFF
--- a/.github/workflows/black-format.yaml
+++ b/.github/workflows/black-format.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/develop-ci-cd.yaml
+++ b/.github/workflows/develop-ci-cd.yaml
@@ -62,11 +62,23 @@ jobs:
           (kubectl -n entebus rollout undo deployment/entebus-server && exit 1)
 
       - name: Clean up old develop images
-        uses: actions/delete-package-versions@v6
-        with:
-          package-name: ${{ github.event.repository.name }}
-          package-type: container
-          min-versions-to-keep: 5
-          delete-only-package-versions-matching: "^develop-[0-9a-f]{7}$"
-          ignore-versions: "^develop-latest$"
-          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OWNER_TYPE=$(gh api "/repos/${{ github.repository }}" --jq '.owner.type')
+          OWNER="${{ github.repository_owner }}"
+          PKG="${{ github.event.repository.name }}"
+
+          if [ "$OWNER_TYPE" = "Organization" ]; then
+            API_PATH="/orgs/${OWNER}/packages/container/${PKG}/versions"
+          else
+            API_PATH="/user/packages/container/${PKG}/versions"
+          fi
+
+          VERSIONS=$(gh api "$API_PATH" \
+            --paginate \
+            --jq '[.[] | select(any(.metadata.container.tags[]; test("^develop-[0-9a-f]{7}$")))] | sort_by(.created_at) | reverse | .[5:] | .[].id')
+
+          for VERSION_ID in $VERSIONS; do
+            gh api --method DELETE "${API_PATH}/${VERSION_ID}"
+          done

--- a/.github/workflows/develop-ci-cd.yaml
+++ b/.github/workflows/develop-ci-cd.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -46,7 +46,7 @@ jobs:
           docker push "${IMAGE_NAME}:develop-${SHORT_SHA}"
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v4
         with:
           version: "v1.35.2"
 
@@ -62,7 +62,7 @@ jobs:
           (kubectl -n entebus rollout undo deployment/entebus-server && exit 1)
 
       - name: Clean up old develop images
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@v6
         with:
           package-name: ${{ github.event.repository.name }}
           package-type: container

--- a/.github/workflows/main-ci-cd.yaml
+++ b/.github/workflows/main-ci-cd.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v4
         with:
           version: "v1.35.2"
 


### PR DESCRIPTION
### **Summary of Changes**
- Fixed old develop container image clean-up logic.
- Added support for both user and organization repositories when fetching package versions.
- Updated cleanup flow to delete only old develop-<sha> tagged container images while keeping the latest 5 versions.

### **How to Test / Verify**
- Run the develop CI/CD workflow.
- Verify old develop container images are cleaned up correctly.
- Confirm the latest 5 develop images are retained.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
