### PR TITLE
Enforce per company route limit

### DIFF
--- a/app/api/route.py
+++ b/app/api/route.py
@@ -359,7 +359,6 @@ GET_DESCRIPTION = Description().add_head("Fetches a list of routes.")
     description=(
         POST_DESCRIPTION.copy()
         .add_line("Logged-in executive must have `company.route.create` permission.")
-        .add_line("Duplicate route names are not allowed.")
         .add_line(f"Maximum `{MAX_ROUTES_PER_COMPANY}` routes allowed per company.")
         .to_string()
     ),
@@ -508,7 +507,6 @@ async def fetch_routes_for_executive(
     description=(
         POST_DESCRIPTION.copy()
         .add_line("Logged-in operator must have `company.route.create` permission.")
-        .add_line("Duplicate route names are not allowed.")
         .add_line(f"Maximum `{MAX_ROUTES_PER_COMPANY}` routes allowed per company.")
         .to_string()
     ),

--- a/app/api/route.py
+++ b/app/api/route.py
@@ -56,6 +56,7 @@ from app.src.filters import (
 from app.src.permissions.executive import PermissionPath as ExecutivePermissionPath
 from app.src.permissions.operator import PermissionPath as OperatorPermissionPath
 from app.src.enums import OrderIn, RouteStatus
+from app.src.constants import MAX_ROUTES_PER_COMPANY
 
 route_executive = APIRouter()
 route_operator = APIRouter()
@@ -172,6 +173,13 @@ def create_route(session: Session, form_param: CreateForm) -> dict:
     Returns:
         dict: The created route data.
     """
+    route_count = (
+        session.query(Route).filter(Route.company_id == form_param.company_id).count()
+    )
+
+    if route_count >= MAX_ROUTES_PER_COMPANY:
+        raise exceptions.LimitExceeded(Route)
+
     route = Route(
         company_id=form_param.company_id,
         name=form_param.name,
@@ -342,11 +350,17 @@ GET_DESCRIPTION = Description().add_head("Fetches a list of routes.")
     response_model=RouteSchema,
     status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(
-        [*POST_EXCEPTIONS, exceptions.UnknownValue(Route.company_id)]
+        [
+            *POST_EXCEPTIONS,
+            exceptions.UnknownValue(Route.company_id),
+            exceptions.LimitExceeded(Route),
+        ]
     ),
     description=(
         POST_DESCRIPTION.copy()
         .add_line("Logged-in executive must have `company.route.create` permission.")
+        .add_line("Duplicate route names are not allowed.")
+        .add_line(f"Maximum `{MAX_ROUTES_PER_COMPANY}` routes allowed per company.")
         .to_string()
     ),
 )
@@ -485,10 +499,17 @@ async def fetch_routes_for_executive(
     tags=["Route"],
     response_model=RouteSchema,
     status_code=status.HTTP_201_CREATED,
-    responses=fuse_exception_responses(POST_EXCEPTIONS),
+    responses=fuse_exception_responses(
+        [
+            *POST_EXCEPTIONS,
+            exceptions.LimitExceeded(Route),
+        ]
+    ),
     description=(
         POST_DESCRIPTION.copy()
         .add_line("Logged-in operator must have `company.route.create` permission.")
+        .add_line("Duplicate route names are not allowed.")
+        .add_line(f"Maximum `{MAX_ROUTES_PER_COMPANY}` routes allowed per company.")
         .to_string()
     ),
 )

--- a/app/api/route.py
+++ b/app/api/route.py
@@ -297,6 +297,7 @@ def search_route(session: Session, query_params: QueryParams) -> List[Route]:
 POST_EXCEPTIONS = [
     exceptions.InvalidToken(),
     exceptions.NoPermission(),
+    exceptions.LimitExceeded(Route),
 ]
 
 PATCH_EXCEPTIONS = [
@@ -323,6 +324,7 @@ POST_DESCRIPTION = (
     .add_head("Creates a new route.")
     .add_line("Duplicate route names are not allowed.")
     .add_line("By default the status of the route is INVALID.")
+    .add_line(f"Maximum `{MAX_ROUTES_PER_COMPANY}` routes allowed per company.")
 )
 
 PATCH_DESCRIPTION = (
@@ -353,13 +355,11 @@ GET_DESCRIPTION = Description().add_head("Fetches a list of routes.")
         [
             *POST_EXCEPTIONS,
             exceptions.UnknownValue(Route.company_id),
-            exceptions.LimitExceeded(Route),
         ]
     ),
     description=(
         POST_DESCRIPTION.copy()
         .add_line("Logged-in executive must have `company.route.create` permission.")
-        .add_line(f"Maximum `{MAX_ROUTES_PER_COMPANY}` routes allowed per company.")
         .to_string()
     ),
 )
@@ -507,7 +507,6 @@ async def fetch_routes_for_executive(
     description=(
         POST_DESCRIPTION.copy()
         .add_line("Logged-in operator must have `company.route.create` permission.")
-        .add_line(f"Maximum `{MAX_ROUTES_PER_COMPANY}` routes allowed per company.")
         .to_string()
     ),
 )

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -63,7 +63,6 @@ MINIO_PASSWORD = environ.get("MINIO_PASSWORD", "password")
 # ---------------------------------------------------------------------------
 MAX_EXECUTIVE_TOKENS = 5  # Maximum tokens per executive
 MAX_OPERATOR_TOKENS = 5  # Maximum tokens per operator
-MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company
 MAX_VENDOR_TOKENS = 1  # Maximum tokens per vendor
 MAX_REFRESH_TOKEN_VALIDITY = (
     7 * 24 * 60 * 60
@@ -128,3 +127,10 @@ MAX_IMAGE_RESOLUTION = 4096  # Maximum allowed width/height in pixels
 MIN_IMAGE_RESOLUTION = 16  # Minimum allowed width/height in pixels
 MAX_IMAGE_FILE_SIZE = 10 * 1024 * 1024  # Maximum allowed file size in bytes (10 MB)
 MIN_IMAGE_FILE_SIZE = 1 * 1024  # Minimum allowed file size in bytes (1 KB)
+
+
+# ---------------------------------------------------------------------------
+# Company constraints
+# ---------------------------------------------------------------------------
+MAX_ROUTES_PER_COMPANY = 100  # Maximum routes per company
+MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
Reason for the change?
-  Added validation to restrict the number of routes that can be created for a company. This prevents excessive route creation -and helps maintain system constraints and better route management.

What changed? 
- Added maximum route limit validation per company
- Restricted route creation when the configured limit is reached
- Added handling for route limit exceeded scenarios following the existing project structure

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Set MAX_ROUTES_PER_COMPANY = 4 for easier API testing.
- Create the first 4 routes for the same company using the route creation API.
- Verify that all 4 routes are created successfully.
- Attempt to create a 5th route for the same company.
- Verify that the API blocks route creation and returns the appropriate limit exceeded response.

### **Checklist (Self-Review)**
- [X] I have tested the changes locally or in a staging environment.
- [X] I have reviewed my own code for potential issues.
- [X] I have applied code formatting/linting.
- [X] I have added or updated tests as needed.
- [X] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
