### PR TITLE
Developed vehicle creation limit per company

### DIFF
--- a/app/api/vehicle.py
+++ b/app/api/vehicle.py
@@ -28,7 +28,7 @@ from app.src.enums import (
     OrderIn,
     VehicleStatus,
 )
-from app.src.constants import TMZ_PRIMARY
+from app.src.constants import TMZ_PRIMARY, MAX_VEHICLE_CREATION_OPERATOR_LIMIT
 from app.src.permissions.executive import PermissionPath as ExecutivePermissionPath
 from app.src.permissions.operator import PermissionPath as OperatorPermissionPath
 from app.src import exceptions
@@ -559,6 +559,7 @@ async def fetch_vehicles_for_executive(
             exceptions.InvalidToken(),
             exceptions.NoPermission(),
             exceptions.InvalidValue(Vehicle.manufactured_on),
+            exceptions.LimitExceeded(Vehicle),
         ]
     ),
     description=(
@@ -568,7 +569,8 @@ async def fetch_vehicles_for_executive(
             - Logged-in operator must have `company.vehicle.create` permission.    
             - Duplicate registration numbers are not allowed.    
             - Manufactured date cannot be in the future.    
-            - By default, the vehicle status is set to `CREATED`.    
+            - By default, the vehicle status is set to `CREATED`. 
+            - Maximum `{MAX_VEHICLE_CREATION_OPERATOR_LIMIT}` vehicle creation allowed per operator 
         """
     ),
 )
@@ -582,6 +584,15 @@ async def create_vehicle_for_operator(
         token = verify_token(session, OperatorToken, access_token.credentials)
         roles = get_operator_roles(session, token)
         verify_permission(roles, OperatorPermissionPath.CREATE_COMPANY_VEHICLE)
+
+        vehicle_count = (
+            session.query(Vehicle)
+            .filter(Vehicle.company_id == token.company_id)
+            .count()
+        )
+
+        if vehicle_count >= MAX_VEHICLE_CREATION_OPERATOR_LIMIT:
+            raise exceptions.LimitExceeded(Vehicle)
 
         vehicle_data = create_vehicle(
             session,

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -128,3 +128,8 @@ MAX_IMAGE_RESOLUTION = 4096  # Maximum allowed width/height in pixels
 MIN_IMAGE_RESOLUTION = 16  # Minimum allowed width/height in pixels
 MAX_IMAGE_FILE_SIZE = 10 * 1024 * 1024  # Maximum allowed file size in bytes (10 MB)
 MIN_IMAGE_FILE_SIZE = 1 * 1024  # Minimum allowed file size in bytes (1 KB)
+
+# ---------------------------------------------------------------------------
+# Vehicle constants
+# ---------------------------------------------------------------------------
+MAX_VEHICLE_CREATION_OPERATOR_LIMIT = 2  # Maximum number of vehicle per comapany


### PR DESCRIPTION
### **Summary of Changes**

<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
Reason for the change?

- Added validation to restrict the number of vehicles that can be created per company for operators. This prevents excessive        
vehicle creation, avoids misuse of system resources, and ensures vehicle creation is controlled through application-level enforcement.

 What changed? 

- Added vehicle limit validation per company
- Restricted operators from creating more than 2 vehicles
- Added proper error handling when the vehicle limit is exceeded
- Implemented validation in application logic without database change

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->

- Set MAX_VEHICLE_CREATION_OPERATOR_LIMIT = 2 for testing.
- Create the first 2 vehicles for the same company using the vehicle creation API as an operator.
- Verify that all 2 vehicles are created successfully.
- Attempt to create a 5th vehicle for the same company as an operator.
- Verify that the API blocks vehicle creation and returns the appropriate limit exceeded response with X-Error header.



### **Checklist (Self-Review)**
- [X] I have tested the changes locally or in a staging environment.
- [X] I have reviewed my own code for potential issues.
- [X] I have applied code formatting/linting.
- [X] I have added or updated tests as needed.
- [X] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->


### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
