### PR TITLE
Implement Redis Mutex Locking for Landmark-in-Route

### DIFF
--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -41,6 +41,7 @@ from app.src.functions import (
     apply_created_on_filters,
     apply_updated_on_filters,
 )
+from app.src.redis import acquire_lock, release_lock
 from app.src.enums import RouteStatus
 from app.src.filters import (
     IDFilter,
@@ -176,41 +177,46 @@ def create_landmark_in_route(
         LandmarkInRoute.route_id,
         extra_filter=extra_filter_for_route,
     )
-    landmark_count = (
-        session.query(LandmarkInRoute)
-        .filter(
-            LandmarkInRoute.route_id == route.id,
+    route_lock = None
+    try:
+        route_lock = acquire_lock(route.id)
+        landmark_count = (
+            session.query(LandmarkInRoute)
+            .filter(
+                LandmarkInRoute.route_id == route.id,
+            )
+            .count()
         )
-        .count()
-    )
-    if landmark_count >= MAX_LANDMARKS_PER_ROUTE:
-        raise exceptions.LimitExceeded(LandmarkInRoute)
+        if landmark_count >= MAX_LANDMARKS_PER_ROUTE:
+            raise exceptions.LimitExceeded(LandmarkInRoute)
 
-    validate_id(session, Landmark, form_param.landmark_id, LandmarkInRoute.landmark_id)
-    if form_param.arrival_delta > form_param.departure_delta:
-        raise exceptions.InvalidValue(LandmarkInRoute.arrival_delta)
+        validate_id(session, Landmark, form_param.landmark_id, LandmarkInRoute.landmark_id)
+        if form_param.arrival_delta > form_param.departure_delta:
+            raise exceptions.InvalidValue(LandmarkInRoute.arrival_delta)
 
-    landmark_in_route = LandmarkInRoute(
-        company_id=route.company_id,
-        route_id=form_param.route_id,
-        landmark_id=form_param.landmark_id,
-        distance_from_start=form_param.distance_from_start,
-        arrival_delta=form_param.arrival_delta,
-        departure_delta=form_param.departure_delta,
-    )
-    session.add(landmark_in_route)
-    session.flush()
+        landmark_in_route = LandmarkInRoute(
+            company_id=route.company_id,
+            route_id=form_param.route_id,
+            landmark_id=form_param.landmark_id,
+            distance_from_start=form_param.distance_from_start,
+            arrival_delta=form_param.arrival_delta,
+            departure_delta=form_param.departure_delta,
+        )
+        session.add(landmark_in_route)
+        session.flush()
 
-    is_valid = validate_route(route.id, session)
-    if is_valid:
-        route.status = RouteStatus.VALID
-    else:
-        route.status = RouteStatus.INVALID
+        is_valid = validate_route(route.id, session)
+        if is_valid:
+            route.status = RouteStatus.VALID
+        else:
+            route.status = RouteStatus.INVALID
 
-    session.commit()
-    session.refresh(landmark_in_route)
-    landmark_in_route_data = jsonable_encoder(landmark_in_route)
-    return landmark_in_route_data
+        session.commit()
+        session.refresh(landmark_in_route)
+        landmark_in_route_data = jsonable_encoder(landmark_in_route)
+        return landmark_in_route_data
+    finally:
+        release_lock(route_lock)
 
 
 def update_landmark_in_route(
@@ -239,44 +245,50 @@ def update_landmark_in_route(
         extra_filter=extra_filter_for_landmark_in_route,
     )
 
-    arrival_delta = (
-        form_param.arrival_delta
-        if form_param.arrival_delta is not None
-        else landmark_in_route.arrival_delta
-    )
-    departure_delta = (
-        form_param.departure_delta
-        if form_param.departure_delta is not None
-        else landmark_in_route.departure_delta
-    )
+    route_lock = None
+    try:
+        route_lock = acquire_lock(landmark_in_route.route_id)
 
-    if (
-        arrival_delta is not None
-        and departure_delta is not None
-        and arrival_delta > departure_delta
-    ):
-        raise exceptions.InvalidValue(LandmarkInRoute.arrival_delta)
+        arrival_delta = (
+            form_param.arrival_delta
+            if form_param.arrival_delta is not None
+            else landmark_in_route.arrival_delta
+        )
+        departure_delta = (
+            form_param.departure_delta
+            if form_param.departure_delta is not None
+            else landmark_in_route.departure_delta
+        )
 
-    route = validate_id(
-        session, Route, landmark_in_route.route_id, LandmarkInRoute.route_id
-    )
+        if (
+            arrival_delta is not None
+            and departure_delta is not None
+            and arrival_delta > departure_delta
+        ):
+            raise exceptions.InvalidValue(LandmarkInRoute.arrival_delta)
 
-    update_data = form_param.model_dump(exclude_unset=True)
-    update_if_changed(landmark_in_route, update_data)
+        route = validate_id(
+            session, Route, landmark_in_route.route_id, LandmarkInRoute.route_id
+        )
 
-    have_updates = session.is_modified(landmark_in_route)
-    if have_updates:
-        is_valid = validate_route(route.id, session)
-        if is_valid:
-            route.status = RouteStatus.VALID
-        else:
-            route.status = RouteStatus.INVALID
+        update_data = form_param.model_dump(exclude_unset=True)
+        update_if_changed(landmark_in_route, update_data)
 
-        session.commit()
-        session.refresh(landmark_in_route)
+        have_updates = session.is_modified(landmark_in_route)
+        if have_updates:
+            is_valid = validate_route(route.id, session)
+            if is_valid:
+                route.status = RouteStatus.VALID
+            else:
+                route.status = RouteStatus.INVALID
 
-    landmark_in_route_data = jsonable_encoder(landmark_in_route)
-    return have_updates, landmark_in_route_data
+            session.commit()
+            session.refresh(landmark_in_route)
+
+        landmark_in_route_data = jsonable_encoder(landmark_in_route)
+        return have_updates, landmark_in_route_data
+    finally:
+        release_lock(route_lock)
 
 
 def delete_landmark_in_route(

--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -403,7 +403,7 @@ POST_EXCEPTIONS = [
     exceptions.UnknownValue(LandmarkInRoute.route_id),
     exceptions.UnknownValue(LandmarkInRoute.landmark_id),
     exceptions.LimitExceeded(LandmarkInRoute),
-    exceptions.LockAcquireTimeout()
+    exceptions.LockAcquireTimeout(),
 ]
 
 PATCH_EXCEPTIONS = [
@@ -411,13 +411,13 @@ PATCH_EXCEPTIONS = [
     exceptions.NoPermission(),
     exceptions.InvalidValue(LandmarkInRoute.arrival_delta),
     exceptions.UnknownValue(LandmarkInRoute.id),
-    exceptions.LockAcquireTimeout()
+    exceptions.LockAcquireTimeout(),
 ]
 
 DELETE_EXCEPTIONS = [
     exceptions.InvalidToken(),
     exceptions.NoPermission(),
-    exceptions.LockAcquireTimeout()
+    exceptions.LockAcquireTimeout(),
 ]
 
 GET_EXCEPTIONS = [

--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -156,9 +156,13 @@ class QueryParams(QueryParamsForEX):
 # ---------------------------------------------------------------------------
 ## Lock Generator
 # ---------------------------------------------------------------------------
-def create_route_lock(route_id: int) -> str:
+def construct_route_transition_lock(route_id: int) -> str:
     """
-    Creates a unique Redis lock key for a specific route.
+    Creates a Redis lock key used to prevent concurrent route transition operations.
+
+    Prevents concurrent create, update, and delete operations on the same
+    route, as these actions can affect the route's status and validation.
+    Only one operation is allowed at a time.
 
     Args:
         route_id (int): The ID of the route for which to create the lock.
@@ -183,16 +187,16 @@ def create_landmark_in_route(
     Returns:
         dict: The created landmark in route data.
     """
-    route = validate_id(
-        session,
-        Route,
-        form_param.route_id,
-        LandmarkInRoute.route_id,
-        extra_filter=extra_filter_for_route,
-    )
     route_lock = None
     try:
-        route_lock = acquire_lock(create_route_lock(route.id))
+        route = validate_id(
+            session,
+            Route,
+            form_param.route_id,
+            LandmarkInRoute.route_id,
+            extra_filter=extra_filter_for_route,
+        )
+        route_lock = acquire_lock(construct_route_transition_lock(route.id))
         landmark_count = (
             session.query(LandmarkInRoute)
             .filter(
@@ -252,17 +256,19 @@ def update_landmark_in_route(
     Returns:
         Tuple[bool, dict]: A tuple containing a boolean indicating if updates were made and the updated landmark in route data.
     """
-    landmark_in_route = validate_id(
-        session,
-        LandmarkInRoute,
-        id,
-        LandmarkInRoute.id,
-        extra_filter=extra_filter_for_landmark_in_route,
-    )
-
     route_lock = None
     try:
-        route_lock = acquire_lock(create_route_lock(landmark_in_route.route_id))
+        landmark_in_route = validate_id(
+            session,
+            LandmarkInRoute,
+            id,
+            LandmarkInRoute.id,
+            extra_filter=extra_filter_for_landmark_in_route,
+        )
+
+        route_lock = acquire_lock(
+            construct_route_transition_lock(landmark_in_route.route_id)
+        )
         arrival_delta = (
             form_param.arrival_delta
             if form_param.arrival_delta is not None
@@ -318,12 +324,12 @@ def delete_landmark_in_route(
     Returns:
         dict: The deleted landmark in route data.
     """
-    route = validate_id(
-        session, Route, landmark_in_route.route_id, LandmarkInRoute.route_id
-    )
     route_lock = None
     try:
-        route_lock = acquire_lock(create_route_lock(route.id))
+        route = validate_id(
+            session, Route, landmark_in_route.route_id, LandmarkInRoute.route_id
+        )
+        route_lock = acquire_lock(construct_route_transition_lock(route.id))
         landmark_in_route_data = jsonable_encoder(landmark_in_route)
         session.delete(landmark_in_route)
         session.flush()

--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -156,6 +156,16 @@ class QueryParams(QueryParamsForEX):
 # ---------------------------------------------------------------------------
 ## Functions
 # ---------------------------------------------------------------------------
+def create_route_lock(route_id: int) -> str:
+    """
+    Creates a unique Redis lock key for a specific route.
+
+    Args:
+        route_id (int): The ID of the route for which to create the lock.
+    """
+    return f"route_lock:{route_id}"
+
+
 def create_landmark_in_route(
     session: Session, form_param: CreateForm, extra_filter_for_route=None
 ) -> dict:
@@ -179,7 +189,7 @@ def create_landmark_in_route(
     )
     route_lock = None
     try:
-        route_lock = acquire_lock(route.id)
+        route_lock = acquire_lock(create_route_lock(route.id))
         landmark_count = (
             session.query(LandmarkInRoute)
             .filter(
@@ -249,7 +259,7 @@ def update_landmark_in_route(
 
     route_lock = None
     try:
-        route_lock = acquire_lock(landmark_in_route.route_id)
+        route_lock = acquire_lock(create_route_lock(landmark_in_route.route_id))
         arrival_delta = (
             form_param.arrival_delta
             if form_param.arrival_delta is not None
@@ -310,7 +320,7 @@ def delete_landmark_in_route(
     )
     route_lock = None
     try:
-        route_lock = acquire_lock(route.id)
+        route_lock = acquire_lock(create_route_lock(route.id))
         landmark_in_route_data = jsonable_encoder(landmark_in_route)
         session.delete(landmark_in_route)
         session.flush()

--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -190,7 +190,9 @@ def create_landmark_in_route(
         if landmark_count >= MAX_LANDMARKS_PER_ROUTE:
             raise exceptions.LimitExceeded(LandmarkInRoute)
 
-        validate_id(session, Landmark, form_param.landmark_id, LandmarkInRoute.landmark_id)
+        validate_id(
+            session, Landmark, form_param.landmark_id, LandmarkInRoute.landmark_id
+        )
         if form_param.arrival_delta > form_param.departure_delta:
             raise exceptions.InvalidValue(LandmarkInRoute.arrival_delta)
 
@@ -248,7 +250,6 @@ def update_landmark_in_route(
     route_lock = None
     try:
         route_lock = acquire_lock(landmark_in_route.route_id)
-
         arrival_delta = (
             form_param.arrival_delta
             if form_param.arrival_delta is not None
@@ -307,17 +308,22 @@ def delete_landmark_in_route(
     route = validate_id(
         session, Route, landmark_in_route.route_id, LandmarkInRoute.route_id
     )
-    landmark_in_route_data = jsonable_encoder(landmark_in_route)
-    session.delete(landmark_in_route)
-    session.flush()
-    is_valid = validate_route(route.id, session)
-    if is_valid:
-        route.status = RouteStatus.VALID
-    else:
-        route.status = RouteStatus.INVALID
+    route_lock = None
+    try:
+        route_lock = acquire_lock(route.id)
+        landmark_in_route_data = jsonable_encoder(landmark_in_route)
+        session.delete(landmark_in_route)
+        session.flush()
+        is_valid = validate_route(route.id, session)
+        if is_valid:
+            route.status = RouteStatus.VALID
+        else:
+            route.status = RouteStatus.INVALID
 
-    session.commit()
-    return landmark_in_route_data
+        session.commit()
+        return landmark_in_route_data
+    finally:
+        release_lock(route_lock)
 
 
 def search_landmark_in_route(

--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -403,6 +403,7 @@ POST_EXCEPTIONS = [
     exceptions.UnknownValue(LandmarkInRoute.route_id),
     exceptions.UnknownValue(LandmarkInRoute.landmark_id),
     exceptions.LimitExceeded(LandmarkInRoute),
+    exceptions.LockAcquireTimeout()
 ]
 
 PATCH_EXCEPTIONS = [
@@ -410,11 +411,13 @@ PATCH_EXCEPTIONS = [
     exceptions.NoPermission(),
     exceptions.InvalidValue(LandmarkInRoute.arrival_delta),
     exceptions.UnknownValue(LandmarkInRoute.id),
+    exceptions.LockAcquireTimeout()
 ]
 
 DELETE_EXCEPTIONS = [
     exceptions.InvalidToken(),
     exceptions.NoPermission(),
+    exceptions.LockAcquireTimeout()
 ]
 
 GET_EXCEPTIONS = [

--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -154,7 +154,7 @@ class QueryParams(QueryParamsForEX):
 
 
 # ---------------------------------------------------------------------------
-## Functions
+## Lock Generator
 # ---------------------------------------------------------------------------
 def create_route_lock(route_id: int) -> str:
     """
@@ -163,9 +163,12 @@ def create_route_lock(route_id: int) -> str:
     Args:
         route_id (int): The ID of the route for which to create the lock.
     """
-    return f"route_lock:{route_id}"
+    return f"lk_route_:{route_id}"
 
 
+# ---------------------------------------------------------------------------
+## Functions
+# ---------------------------------------------------------------------------
 def create_landmark_in_route(
     session: Session, form_param: CreateForm, extra_filter_for_route=None
 ) -> dict:

--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -197,6 +197,8 @@ def create_landmark_in_route(
             extra_filter=extra_filter_for_route,
         )
         route_lock = acquire_lock(construct_route_transition_lock(route.id))
+        session.refresh(route)
+
         landmark_count = (
             session.query(LandmarkInRoute)
             .filter(
@@ -332,6 +334,8 @@ def delete_landmark_in_route(
             session, Route, landmark_in_route.route_id, LandmarkInRoute.route_id
         )
         route_lock = acquire_lock(construct_route_transition_lock(route.id))
+        session.refresh(route)
+
         landmark_in_route_data = jsonable_encoder(landmark_in_route)
         session.delete(landmark_in_route)
         session.flush()

--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -269,6 +269,8 @@ def update_landmark_in_route(
         route_lock = acquire_lock(
             construct_route_transition_lock(landmark_in_route.route_id)
         )
+        session.refresh(landmark_in_route)
+
         arrival_delta = (
             form_param.arrival_delta
             if form_param.arrival_delta is not None


### PR DESCRIPTION
### **Summary of Changes**
- Added route-level Redis mutex locking to Landmark In Route create, update, and delete operations.
- Locks are acquired using the associated route ID to serialize concurrent modifications on the same route.
- Locks are released in finally blocks to ensure proper cleanup.

### **How to Test / Verify**
- Create, update, and delete landmarks in a route and verify existing behavior remains unchanged.
- Send concurrent requests against the same route and verify they are processed sequentially.
- Verify route validation and route status updates continue to work correctly.
- Verify locks are released correctly when requests fail with validation or database errors.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
