### PR TITLE
Batch upload feature for ticket creation

### DIFF
--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -13,7 +13,6 @@ from fastapi import APIRouter, Depends, status, Query
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from sqlalchemy.orm.session import Session
-from yaml import warnings
 
 from app.api.bearer import bearer_operator, oauth2_executive
 from app.src.db import (
@@ -25,6 +24,7 @@ from app.src.db import (
     Duty,
     FareInService,
     LandmarkInService,
+    Operator,
 )
 from app.src.enums import DutyStatus, ServiceStatus, OrderIn
 from app.src.urls import URL_PAPER_TICKET
@@ -56,9 +56,20 @@ route_operator = APIRouter()
 # ---------------------------------------------------------------------------
 ## Output Schema
 # ---------------------------------------------------------------------------
-class PaperTicketSchema(BaseModel):
-    """Schema for paper ticket response."""
+class TicketSchema(BaseModel):
+    operator_id: int | None
+    sequence_id: int
+    created_on: datetime
+    ticket_types: List[TicketTypeSchema]
+    amount: TwoDecimalPlaces
+    pickup_point: int
+    dropping_point: int
+    extras: dict
+    warnings: List[PaperTicketWarning] = Field(default_factory=list)
+    uploaded_by: int | None
 
+
+class PaperTicketSchema(BaseModel):
     id: int
     service_id: int
     duty_id: int
@@ -130,7 +141,7 @@ class QueryParams(QueryParamsForEX):
 # ---------------------------------------------------------------------------
 def create_paper_ticket(
     session: Session, token: OperatorToken, form_param: CreateForm
-) -> dict:
+) -> List[dict]:
     """
     create a new paper ticket in the database.
 
@@ -140,13 +151,12 @@ def create_paper_ticket(
         form_param (CreateForm): Validated input data for creating the paper ticket, including service ID, ticket details, and total amount.
 
     Raises:
-        exceptions.UnknownValue: If the service ID does not correspond to a valid service for the operator's company, or if the boarding/alight landmarks are not valid for the service.
-        exceptions.InactiveResource: If the duty associated with the service is in a state that cannot accept new tickets (e.g., AUDITED).
-        exceptions.InvalidValue: If the provided amount does not match the calculated total fare, or if any ticket type has an invalid price.
+        exceptions.UnknownValue: If the service ID does not correspond to a valid service for the operator's company, or if required landmarks are missing.
+        exceptions.InactiveResource: If a resource state prevents ticket creation.
         exceptions.UnknownTicketType: If any ticket type ID in the input does not match the ticket types defined in the service fare configuration.
 
     Returns:
-        dict: The created paper ticket data.
+        List[dict]: List of created paper ticket records as JSON-serializable dicts. Each ticket payload may include `uploaded_by` and `warnings`.
     """
     service_lock = None
     try:
@@ -162,6 +172,8 @@ def create_paper_ticket(
             PaperTicket.service_id,
             (Service.company_id == token.company_id),
         )
+        service_lock = acquire_lock(construct_service_transition_lock(service.id))
+        session.refresh(service)
         # Batch fetch all landmarks for the service
         landmarks_in_service = (
             session.query(LandmarkInService)
@@ -175,19 +187,18 @@ def create_paper_ticket(
             pickup_point = landmarks_map.get(ticket.pickup_point)
             if pickup_point is None:
                 raise exceptions.UnknownValue("pickup_point")
-
             dropping_point = landmarks_map.get(ticket.dropping_point)
             if dropping_point is None:
                 raise exceptions.UnknownValue("dropping_point")
-
             distance = (
                 dropping_point.distance_from_start - pickup_point.distance_from_start
             )
             if distance < 0:
                 raise exceptions.UnknownValue("dropping_point")
-            if distance != ticket.distance:
-                raise exceptions.UnknownValue("distance")
+            # if distance != ticket.distance:
+            #     raise exceptions.UnknownValue("distance")
 
+        # Batch fetch fare configuration
         fare_in_service = (
             session.query(FareInService)
             .filter(FareInService.id == service.fare_in_service_id)
@@ -195,73 +206,129 @@ def create_paper_ticket(
         )
         fare_function = v1.DynamicFare(fare_in_service.function)
         fare_ticket_types = fare_in_service.attributes["ticket_types"]
-        extras = jsonable_encoder(ticket.extras)
-        total_fare = Decimal(0)
+        fare_ticket_types_map = {ft["id"]: ft for ft in fare_ticket_types}
 
-        for ticket_type in ticket.ticket_types:
-            matched_ticket_type = next(
-                (ft for ft in fare_ticket_types if ft["id"] == ticket_type.id),
-                None,
+        # Validate fare and amount for each ticket
+        ticket_warnings_map = {}  # Maps ticket.sequence_id to warnings list
+        for ticket in form_param.tickets:
+            warnings = []
+            ticket_total_fare = Decimal(0)
+            extras = jsonable_encoder(ticket.extras)
+
+            # Calculate distance for this ticket
+            pickup_landmark = landmarks_map.get(ticket.pickup_point)
+            dropping_landmark = landmarks_map.get(ticket.dropping_point)
+            distance = (
+                dropping_landmark.distance_from_start
+                - pickup_landmark.distance_from_start
             )
-            if matched_ticket_type is None:
-                raise exceptions.UnknownTicketType()
 
-            expected_price = Decimal(
-                str(
-                    fare_function.evaluate(
-                        matched_ticket_type["name"], distance, extras
+            # Validate each ticket type and calculate fare
+            for ticket_type in ticket.ticket_types:
+                matched_ticket_type = fare_ticket_types_map.get(ticket_type.id)
+                if matched_ticket_type is None:
+                    raise exceptions.UnknownTicketType()
+
+                expected_price = Decimal(
+                    str(
+                        fare_function.evaluate(
+                            matched_ticket_type["name"], distance, extras
+                        )
                     )
                 )
-            )
-            if ticket_type.price != expected_price:
+                ticket_total_fare += expected_price * ticket_type.count
+
+            # Check for amount mismatch and add warning once if needed
+            if ticket_total_fare != ticket.amount:
                 warnings.append(PaperTicketWarning.AMOUNT_MISMATCH)
 
-            total_fare += ticket_type.price * ticket_type.count
+            ticket_warnings_map[ticket.sequence_id] = warnings
 
-        if total_fare != form_param.ticket.amount:
-            warnings.append(PaperTicketWarning.AMOUNT_MISMATCH)
-
-        service_lock = acquire_lock(construct_service_transition_lock(service.id))
-        session.refresh(service)
         if service.status != ServiceStatus.STARTED:
             service.status = ServiceStatus.STARTED
-        duty = (
-            session.query(Duty)
-            .filter(
-                Duty.service_id == form_param.ticket.service_id,
-                Duty.operator_id == token.operator_id,
-                Duty.status.in_((DutyStatus.STARTED, DutyStatus.ENDED)),
+
+        # Cache for duties keyed by operator_id (None for orphaned duties)
+        duties_cache = {}
+
+        # Create paper tickets for each ticket in the batch
+        paper_tickets = []
+        for ticket in form_param.tickets:
+            warnings = ticket_warnings_map.get(ticket.sequence_id, [])
+
+            # Resolve operator
+            operator = (
+                session.query(Operator)
+                .filter(
+                    Operator.id == ticket.operator_id,
+                    Operator.company_id == token.company_id,
+                )
+                .first()
             )
-            .first()
-        )
-        if duty is None:
-            duty = Duty(
+
+            if operator is None:
+                warnings.append(PaperTicketWarning.OPERATOR_NOT_FOUND)
+            else:
+                if operator.id != token.operator_id:
+                    warnings.append(PaperTicketWarning.OPERATOR_MISMATCH)
+
+            duty_operator_id = operator.id if operator else None
+
+            # Check cache for existing duty
+            if duty_operator_id not in duties_cache:
+                duty = (
+                    session.query(Duty)
+                    .filter(
+                        Duty.service_id == form_param.service_id,
+                        Duty.operator_id == duty_operator_id,
+                        Duty.status.in_((DutyStatus.STARTED, DutyStatus.ENDED)),
+                    )
+                    .first()
+                )
+
+                if duty is None:
+                    # Create new duty
+                    duty = Duty(
+                        company_id=token.company_id,
+                        operator_id=duty_operator_id,
+                        service_id=form_param.service_id,
+                        status=DutyStatus.STARTED,
+                        started_on=ticket.created_on,
+                    )
+                    session.add(duty)
+                    session.flush()
+                elif duty.status == DutyStatus.ENDED:
+                    # Reactivate ended duty
+                    duty.status = DutyStatus.STARTED
+                    duty.finished_on = None
+                    duty.collection = 0
+                    session.flush()
+
+                duties_cache[duty_operator_id] = duty
+            else:
+                duty = duties_cache[duty_operator_id]
+
+            # Build ticket payload
+            ticket_data = ticket.model_dump(mode="json")
+            ticket_data["uploaded_by"] = token.operator_id
+            if warnings:
+                ticket_data["warnings"] = [w.value for w in warnings]
+
+            # Create paper ticket
+            paper_ticket = PaperTicket(
+                service_id=form_param.service_id,
+                duty_id=duty.id,
                 company_id=token.company_id,
-                operator_id=token.operator_id,
-                service_id=form_param.ticket.service_id,
-                status=DutyStatus.STARTED,
-                started_on=form_param.ticket.created_on,
+                ticket=ticket_data,
+                amount=ticket.amount,
             )
-            session.add(duty)
-            session.flush()
-        elif duty.status == DutyStatus.ENDED:
-            duty.status = DutyStatus.STARTED
-            duty.finished_on = None
-            duty.collection = 0
-            session.flush()
+            session.add(paper_ticket)
+            paper_tickets.append(paper_ticket)
 
-        paper_ticket = PaperTicket(
-            service_id=form_param.ticket.service_id,
-            duty_id=duty.id,
-            company_id=token.company_id,
-            ticket=ticket.model_dump(mode="json"),
-            amount=form_param.ticket.amount,
-        )
-        session.add(paper_ticket)
         session.commit()
-        session.refresh(paper_ticket)
+        for paper_ticket in paper_tickets:
+            session.refresh(paper_ticket)
 
-        return jsonable_encoder(paper_ticket)
+        return jsonable_encoder(paper_tickets)
     finally:
         release_lock(service_lock)
 
@@ -339,19 +406,26 @@ POST_DESCRIPTION = (
         "Logged-in operator must have `company.service.ticket.create` permission."
     )
     .add_line("Service must belong to the operator's company.")
-    .add_line("If no active duty exists, a new duty is created automatically.")
+    .add_line("Supports batch uploads")
+    .add_line(
+        "Each ticket may specify its own `operator_id` and will be processed individually."
+    )
+    .add_line(
+        "If an operator is not found, the ticket is attached to an orphaned duty (operator_id = NULL)."
+    )
     .add_line(
         "If a duty is ENDED, it is reactivated to STARTED with `finished_on` cleared."
     )
-    .add_line("A duty in AUDITED status is ignored; a new duty is created instead.")
     .add_line(
-        "`ticket.pickup_point` and `ticket.dropping_point` must be landmarks assigned to the service."
+        "Ticket pickup/dropping points are validated against service landmarks (batch-validated)."
+    )
+    .add_line("Ticket fares are validated server-side using the service fare function.")
+    .add_line(
+        "Amount mismatches do NOT abort the batch; a `AMOUNT_MISMATCH` warning is added to the ticket payload."
     )
     .add_line(
-        "Ticket type IDs must match those defined in the service fare configuration."
+        "If `ticket.operator_id` differs from the uploader, an `OPERATOR_MISMATCH` warning is added and `uploaded_by` records the uploader."
     )
-    .add_line("Prices are cross-validated server-side using the fare function.")
-    .add_line("`amount` must equal the sum of (price × count) for all ticket types.")
 )
 
 GET_DESCRIPTION = Description().add_head("Fetches a list of paper tickets.")
@@ -392,7 +466,7 @@ async def fetch_paper_tickets_for_executive(
     URL_PAPER_TICKET,
     summary="Create paper ticket",
     tags=["Paper Ticket"],
-    response_model=PaperTicketSchema,
+    response_model=List[PaperTicketSchema],
     status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(POST_EXCEPTIONS),
     description=(POST_DESCRIPTION.to_string()),

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -58,7 +58,7 @@ route_operator = APIRouter()
 # ---------------------------------------------------------------------------
 class TicketSchema(BaseModel):
     sequence_id: int
-    warnings: List[PaperTicketWarning] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
     uploaded_by: int | None = None
 
 
@@ -298,7 +298,7 @@ def create_paper_ticket(
                 amount=ticket.amount,
             )
             if warnings:
-                paper_ticket.ticket["warnings"] = [w.value for w in warnings]
+                paper_ticket.ticket["warnings"] = [w.name for w in warnings]
             if token.operator_id != ticket.operator_id:
                 paper_ticket.ticket["uploaded_by"] = token.operator_id
             session.add(paper_ticket)

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -219,6 +219,8 @@ def create_paper_ticket(
                         )
                     )
                 )
+                if ticket_type.price != expected_price:
+                    raise exceptions.InvalidValue(PaperTicket.amount)
                 total_fare += expected_price * ticket_type.count
             if total_fare != ticket.amount:
                 raise exceptions.InvalidValue(PaperTicket.amount)

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -57,32 +57,22 @@ route_operator = APIRouter()
 ## Output Schema
 # ---------------------------------------------------------------------------
 class TicketSchema(BaseModel):
-    operator_id: int | None
     sequence_id: int
-    created_on: datetime
-    ticket_types: List[TicketTypeSchema]
-    amount: TwoDecimalPlaces
-    pickup_point: int
-    dropping_point: int
-    extras: dict
-    warnings: List[PaperTicketWarning] = Field(default_factory=list)
-    uploaded_by: int | None
+    warnings: List[PaperTicketWarning] | None = None
+    uploaded_by: int | None = None
 
 
 class PaperTicketSchema(BaseModel):
     id: int
-    service_id: int
     duty_id: int
-    company_id: int
     ticket: TicketSchema
-    amount: TwoDecimalPlaces
     created_on: datetime
 
 
 # ---------------------------------------------------------------------------
 ## Input Forms
 # ---------------------------------------------------------------------------
-class TicketForm(BaseModel):
+class PaperTicketForm(BaseModel):
     """Form data for a ticket within a paper ticket."""
 
     operator_id: int = Field()
@@ -100,7 +90,7 @@ class CreateForm(BaseModel):
     Form data for creating a new paper ticket."""
 
     service_id: int = Field()
-    tickets: List[TicketForm] = Field(min_length=1, max_length=50)
+    tickets: List[PaperTicketForm] = Field(min_length=1, max_length=50)
 
 
 # ---------------------------------------------------------------------------
@@ -195,8 +185,6 @@ def create_paper_ticket(
             )
             if distance < 0:
                 raise exceptions.UnknownValue("dropping_point")
-            # if distance != ticket.distance:
-            #     raise exceptions.UnknownValue("distance")
 
         # Batch fetch fare configuration
         fare_in_service = (
@@ -265,11 +253,15 @@ def create_paper_ticket(
                 .first()
             )
 
+            ticket_data = ticket.model_dump(mode="json")
             if operator is None:
                 warnings.append(PaperTicketWarning.OPERATOR_NOT_FOUND)
-            else:
-                if operator.id != token.operator_id:
-                    warnings.append(PaperTicketWarning.OPERATOR_MISMATCH)
+            elif operator.id != token.operator_id:
+                warnings.append(PaperTicketWarning.OPERATOR_MISMATCH)
+                ticket_data["uploaded_by"] = token.operator_id
+
+            if warnings:
+                ticket_data["warnings"] = [w.value for w in warnings]
 
             duty_operator_id = operator.id if operator else None
 
@@ -306,12 +298,6 @@ def create_paper_ticket(
                 duties_cache[duty_operator_id] = duty
             else:
                 duty = duties_cache[duty_operator_id]
-
-            # Build ticket payload
-            ticket_data = ticket.model_dump(mode="json")
-            ticket_data["uploaded_by"] = token.operator_id
-            if warnings:
-                ticket_data["warnings"] = [w.value for w in warnings]
 
             # Create paper ticket
             paper_ticket = PaperTicket(
@@ -469,6 +455,7 @@ async def fetch_paper_tickets_for_executive(
     response_model=List[PaperTicketSchema],
     status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(POST_EXCEPTIONS),
+    response_model_exclude_none=True,
     description=(POST_DESCRIPTION.to_string()),
 )
 async def create_paper_ticket_for_operator(

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -404,7 +404,7 @@ POST_DESCRIPTION = (
     .add_line("Ticket fares are validated server-side using the service fare function.")
     .add_line("Amount mismatches will raise an `InvalidValue` exception.")
     .add_line(
-        "If `ticket.operator_id` differs from the uploader, an `OPERATOR_MISMATCH` warning is added and `uploaded_by` records the uploader."
+        "If the specified operator is not found, an `OPERATOR_NOT_FOUND` warning is added. If `ticket.operator_id` differs from the uploader, an `OPERATOR_MISMATCH` warning is added and `uploaded_by` records the uploader."
     )
     .add_line(
         "If no warnings are generated, `warnings` will be empty. `uploaded_by` is only populated when an operator mismatch occurs."

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -45,7 +45,7 @@ from app.src.filters import PaginationFilter, IDFilter, CreatedOnFilter
 from app.src import exceptions
 from app.src.redis import acquire_lock, release_lock
 from app.src.dynamic_fare import v1
-from app.src.digital_ticket.v1 import TwoDecimalPlaces
+from app.src.digital_ticket.v1 import TwoDecimalPlaces, TicketTypeSchema
 from app.api.service import construct_service_transition_lock
 from app.src.enums import PaperTicketWarning
 
@@ -58,7 +58,7 @@ route_operator = APIRouter()
 # ---------------------------------------------------------------------------
 class TicketSchema(BaseModel):
     sequence_id: int
-    warnings: List[PaperTicketWarning] | None = None
+    warnings: List[PaperTicketWarning] = Field(default_factory=list)
     uploaded_by: int | None = None
 
 
@@ -413,6 +413,9 @@ POST_DESCRIPTION = (
     .add_line(
         "If `ticket.operator_id` differs from the uploader, an `OPERATOR_MISMATCH` warning is added and `uploaded_by` records the uploader."
     )
+    .add_line(
+        "If there are no warnings, `warnings` will be an empty list. If there is no operator mismatch, `uploaded_by` will be null."
+    )
 )
 
 GET_DESCRIPTION = Description().add_head("Fetches a list of paper tickets.")
@@ -456,7 +459,6 @@ async def fetch_paper_tickets_for_executive(
     response_model=List[PaperTicketSchema],
     status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(POST_EXCEPTIONS),
-    response_model_exclude_none=True,
     description=(POST_DESCRIPTION.to_string()),
 )
 async def create_paper_ticket_for_operator(

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, status, Query
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from sqlalchemy.orm.session import Session
+from yaml import warnings
 
 from app.api.bearer import bearer_operator, oauth2_executive
 from app.src.db import (
@@ -44,8 +45,9 @@ from app.src.filters import PaginationFilter, IDFilter, CreatedOnFilter
 from app.src import exceptions
 from app.src.redis import acquire_lock, release_lock
 from app.src.dynamic_fare import v1
-from app.src.digital_ticket.v1 import TicketSchema, TwoDecimalPlaces
+from app.src.digital_ticket.v1 import TicketSchema, TicketTypeSchema, TwoDecimalPlaces
 from app.api.service import construct_service_transition_lock
+from app.src.enums import PaperTicketWarning
 
 route_executive = APIRouter()
 route_operator = APIRouter()
@@ -69,11 +71,25 @@ class PaperTicketSchema(BaseModel):
 # ---------------------------------------------------------------------------
 ## Input Forms
 # ---------------------------------------------------------------------------
+class TicketForm(BaseModel):
+    """Form data for a ticket within a paper ticket."""
+
+    operator_id: int = Field()
+    sequence_id: int = Field()
+    created_on: datetime = Field()
+    ticket_types: List[TicketTypeSchema] = Field()
+    amount: TwoDecimalPlaces = Field()
+    pickup_point: int = Field()
+    dropping_point: int = Field()
+    extras: dict = Field(default_factory=dict)
+
+
 class CreateForm(BaseModel):
     """
     Form data for creating a new paper ticket."""
 
-    ticket: TicketSchema = Field()
+    service_id: int = Field()
+    tickets: List[TicketForm] = Field(min_length=1, max_length=50)
 
 
 # ---------------------------------------------------------------------------
@@ -134,70 +150,43 @@ def create_paper_ticket(
     """
     service_lock = None
     try:
+        # Check that all sequence_ids in the batch are unique
+        sequence_ids = [ticket.sequence_id for ticket in form_param.tickets]
+        if len(sequence_ids) != len(set(sequence_ids)):
+            raise exceptions.InvalidValue("sequence_id")
+
         service = validate_id(
             session,
             Service,
-            form_param.ticket.service_id,
+            form_param.service_id,
             PaperTicket.service_id,
             (Service.company_id == token.company_id),
         )
-        service_lock = acquire_lock(construct_service_transition_lock(service.id))
-        session.refresh(service)
-
-        if service.status != ServiceStatus.STARTED:
-            service.status = ServiceStatus.STARTED
-        duty = (
-            session.query(Duty)
-            .filter(
-                Duty.service_id == form_param.ticket.service_id,
-                Duty.operator_id == token.operator_id,
-                Duty.status.in_((DutyStatus.STARTED, DutyStatus.ENDED)),
-            )
-            .first()
-        )
-        if duty is None:
-            duty = Duty(
-                company_id=token.company_id,
-                operator_id=token.operator_id,
-                service_id=form_param.ticket.service_id,
-                status=DutyStatus.STARTED,
-                started_on=form_param.ticket.created_on,
-            )
-            session.add(duty)
-            session.flush()
-        elif duty.status == DutyStatus.ENDED:
-            duty.status = DutyStatus.STARTED
-            duty.finished_on = None
-            duty.collection = 0
-            session.flush()
-
-        ticket = form_param.ticket
-        pickup_point = (
+        # Batch fetch all landmarks for the service
+        landmarks_in_service = (
             session.query(LandmarkInService)
-            .filter(
-                LandmarkInService.service_id == form_param.ticket.service_id,
-                LandmarkInService.landmark_id == ticket.pickup_point,
-            )
-            .first()
+            .filter(LandmarkInService.service_id == form_param.service_id)
+            .all()
         )
-        if pickup_point is None:
-            raise exceptions.UnknownValue("pickup_point")
-        dropping_point = (
-            session.query(LandmarkInService)
-            .filter(
-                LandmarkInService.service_id == form_param.ticket.service_id,
-                LandmarkInService.landmark_id == ticket.dropping_point,
-            )
-            .first()
-        )
-        if dropping_point is None:
-            raise exceptions.UnknownValue("dropping_point")
+        landmarks_map = {lis.landmark_id: lis for lis in landmarks_in_service}
 
-        distance = dropping_point.distance_from_start - pickup_point.distance_from_start
-        if distance < 0:
-            raise exceptions.UnknownValue("dropping_point")
-        if distance != ticket.distance:
-            raise exceptions.UnknownValue("distance")
+        # Validate pickup point, dropping point, and distance for each ticket
+        for ticket in form_param.tickets:
+            pickup_point = landmarks_map.get(ticket.pickup_point)
+            if pickup_point is None:
+                raise exceptions.UnknownValue("pickup_point")
+
+            dropping_point = landmarks_map.get(ticket.dropping_point)
+            if dropping_point is None:
+                raise exceptions.UnknownValue("dropping_point")
+
+            distance = (
+                dropping_point.distance_from_start - pickup_point.distance_from_start
+            )
+            if distance < 0:
+                raise exceptions.UnknownValue("dropping_point")
+            if distance != ticket.distance:
+                raise exceptions.UnknownValue("distance")
 
         fare_in_service = (
             session.query(FareInService)
@@ -225,11 +214,41 @@ def create_paper_ticket(
                 )
             )
             if ticket_type.price != expected_price:
-                raise exceptions.InvalidValue(PaperTicket.amount)
+                warnings.append(PaperTicketWarning.AMOUNT_MISMATCH)
+
             total_fare += ticket_type.price * ticket_type.count
 
         if total_fare != form_param.ticket.amount:
-            raise exceptions.InvalidValue(PaperTicket.amount)
+            warnings.append(PaperTicketWarning.AMOUNT_MISMATCH)
+
+        service_lock = acquire_lock(construct_service_transition_lock(service.id))
+        session.refresh(service)
+        if service.status != ServiceStatus.STARTED:
+            service.status = ServiceStatus.STARTED
+        duty = (
+            session.query(Duty)
+            .filter(
+                Duty.service_id == form_param.ticket.service_id,
+                Duty.operator_id == token.operator_id,
+                Duty.status.in_((DutyStatus.STARTED, DutyStatus.ENDED)),
+            )
+            .first()
+        )
+        if duty is None:
+            duty = Duty(
+                company_id=token.company_id,
+                operator_id=token.operator_id,
+                service_id=form_param.ticket.service_id,
+                status=DutyStatus.STARTED,
+                started_on=form_param.ticket.created_on,
+            )
+            session.add(duty)
+            session.flush()
+        elif duty.status == DutyStatus.ENDED:
+            duty.status = DutyStatus.STARTED
+            duty.finished_on = None
+            duty.collection = 0
+            session.flush()
 
         paper_ticket = PaperTicket(
             service_id=form_param.ticket.service_id,

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -220,8 +220,8 @@ def create_paper_ticket(
                     )
                 )
                 total_fare += expected_price * ticket_type.count
-                if total_fare != ticket.amount:
-                    raise exceptions.InvalidValue(PaperTicket.amount)
+            if total_fare != ticket.amount:
+                raise exceptions.InvalidValue(PaperTicket.amount)
 
             # Check for amount mismatch and operator mismatch, but do not abort the process,
             # instead, record warnings and uploaded_by info in the ticket payload

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -58,7 +58,7 @@ route_operator = APIRouter()
 # ---------------------------------------------------------------------------
 class TicketSchema(BaseModel):
     sequence_id: int
-    warnings: List[str] = Field(default_factory=list)
+    warnings: List[PaperTicketWarning] = Field(default_factory=list)
     uploaded_by: int | None = None
 
 
@@ -298,7 +298,7 @@ def create_paper_ticket(
                 amount=ticket.amount,
             )
             if warnings:
-                paper_ticket.ticket["warnings"] = [w.name for w in warnings]
+                paper_ticket.ticket["warnings"] = [w.value for w in warnings]
             if token.operator_id != ticket.operator_id:
                 paper_ticket.ticket["uploaded_by"] = token.operator_id
             session.add(paper_ticket)

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -8,7 +8,7 @@ Uses Pydantic schemas for input validation and structured output.
 from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
-from typing import List
+from typing import Dict, List
 from fastapi import APIRouter, Depends, status, Query
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
@@ -164,29 +164,18 @@ def create_paper_ticket(
         )
         service_lock = acquire_lock(construct_service_transition_lock(service.id))
         session.refresh(service)
-        # Batch fetch all landmarks for the service
+
+        # Fetch all landmarks in that service and construct a map for validation and distance calculation
         landmarks_in_service = (
             session.query(LandmarkInService)
             .filter(LandmarkInService.service_id == form_param.service_id)
             .all()
         )
-        landmarks_map = {lis.landmark_id: lis for lis in landmarks_in_service}
+        landmarks_in_service_map = {
+            lis.landmark_id: lis for lis in landmarks_in_service
+        }
 
-        # Validate pickup point, dropping point, and distance for each ticket
-        for ticket in form_param.tickets:
-            pickup_point = landmarks_map.get(ticket.pickup_point)
-            if pickup_point is None:
-                raise exceptions.UnknownValue("pickup_point")
-            dropping_point = landmarks_map.get(ticket.dropping_point)
-            if dropping_point is None:
-                raise exceptions.UnknownValue("dropping_point")
-            distance = (
-                dropping_point.distance_from_start - pickup_point.distance_from_start
-            )
-            if distance < 0:
-                raise exceptions.UnknownValue("dropping_point")
-
-        # Batch fetch fare configuration
+        # Fetch fare function and ticket types for the service and construct a map for validation
         fare_in_service = (
             session.query(FareInService)
             .filter(FareInService.id == service.fare_in_service_id)
@@ -196,22 +185,28 @@ def create_paper_ticket(
         fare_ticket_types = fare_in_service.attributes["ticket_types"]
         fare_ticket_types_map = {ft["id"]: ft for ft in fare_ticket_types}
 
-        # Validate fare and amount for each ticket
-        ticket_warnings_map = {}  # Maps ticket.sequence_id to warnings list
+        # Validate each ticket in the batch and collect warnings without aborting the process
+        # Maps ticket.sequence_id to list of warnings for that ticket
+        duty_cache: Dict[int, Duty] = {}  # Cache to store operator_id to Duty mapping
+        paper_tickets: List[PaperTicket] = []
         for ticket in form_param.tickets:
-            warnings = []
-            ticket_total_fare = Decimal(0)
-            extras = jsonable_encoder(ticket.extras)
+            pickup_point = landmarks_in_service_map.get(ticket.pickup_point)
+            if pickup_point is None:
+                raise exceptions.UnknownValue("pickup_point")
 
-            # Calculate distance for this ticket
-            pickup_landmark = landmarks_map.get(ticket.pickup_point)
-            dropping_landmark = landmarks_map.get(ticket.dropping_point)
+            dropping_point = landmarks_in_service_map.get(ticket.dropping_point)
+            if dropping_point is None:
+                raise exceptions.UnknownValue("dropping_point")
+
             distance = (
-                dropping_landmark.distance_from_start
-                - pickup_landmark.distance_from_start
+                dropping_point.distance_from_start - pickup_point.distance_from_start
             )
+            if distance < 0:
+                raise exceptions.UnknownValue("dropping_point")
 
             # Validate each ticket type and calculate fare
+            total_fare = Decimal(0)
+            extras = jsonable_encoder(ticket.extras)
             for ticket_type in ticket.ticket_types:
                 matched_ticket_type = fare_ticket_types_map.get(ticket_type.id)
                 if matched_ticket_type is None:
@@ -224,26 +219,11 @@ def create_paper_ticket(
                         )
                     )
                 )
-                ticket_total_fare += expected_price * ticket_type.count
+                total_fare += expected_price * ticket_type.count
 
-            # Check for amount mismatch and add warning once if needed
-            if ticket_total_fare != ticket.amount:
-                warnings.append(PaperTicketWarning.AMOUNT_MISMATCH)
-
-            ticket_warnings_map[ticket.sequence_id] = warnings
-
-        if service.status != ServiceStatus.STARTED:
-            service.status = ServiceStatus.STARTED
-
-        # Cache for duties keyed by operator_id (None for orphaned duties)
-        duties_cache = {}
-
-        # Create paper tickets for each ticket in the batch
-        paper_tickets = []
-        for ticket in form_param.tickets:
-            warnings = ticket_warnings_map.get(ticket.sequence_id, [])
-
-            # Resolve operator
+            # Check for amount mismatch and operator mismatch, but do not abort the process,
+            # instead, record warnings and uploaded_by info in the ticket payload
+            warnings = []
             operator = (
                 session.query(Operator)
                 .filter(
@@ -252,37 +232,35 @@ def create_paper_ticket(
                 )
                 .first()
             )
-
-            ticket_data = ticket.model_dump(mode="json")
             if operator is None:
                 warnings.append(PaperTicketWarning.OPERATOR_NOT_FOUND)
-            elif operator.id != token.operator_id:
+            if total_fare != ticket.amount:
+                warnings.append(PaperTicketWarning.AMOUNT_MISMATCH)
+            if token.operator_id != ticket.operator_id:
                 warnings.append(PaperTicketWarning.OPERATOR_MISMATCH)
-                ticket_data["uploaded_by"] = token.operator_id
 
-            if warnings:
-                ticket_data["warnings"] = [w.value for w in warnings]
-
-            duty_operator_id = operator.id if operator else None
-
-            # Check cache for existing duty
-            if duty_operator_id not in duties_cache:
+            if operator is not None:
+                operator_id = operator.id
+            else:
+                operator_id = None  # Orphaned duty for missing operator
+            # Check cache for existing duty for the operator
+            duty = None
+            if operator_id not in duty_cache:
                 duty = (
                     session.query(Duty)
                     .filter(
                         Duty.service_id == form_param.service_id,
-                        Duty.operator_id == duty_operator_id,
+                        Duty.operator_id == operator_id,
                         Duty.status.in_((DutyStatus.STARTED, DutyStatus.ENDED)),
                     )
-                    .order_by(Duty.id.desc())
                     .first()
                 )
 
+                # Create new duty if not found, or reactivate if ended
                 if duty is None:
-                    # Create new duty
                     duty = Duty(
                         company_id=token.company_id,
-                        operator_id=duty_operator_id,
+                        operator_id=operator_id,
                         service_id=form_param.service_id,
                         status=DutyStatus.STARTED,
                         started_on=ticket.created_on,
@@ -296,25 +274,39 @@ def create_paper_ticket(
                     duty.collection = 0
                     session.flush()
 
-                duties_cache[duty_operator_id] = duty
+                duty_cache[operator_id] = duty
             else:
-                duty = duties_cache[duty_operator_id]
+                duty = duty_cache[operator_id]
 
-            # Create paper ticket
+            # Create paper ticket with warnings and uploaded_by info if applicable
             paper_ticket = PaperTicket(
                 service_id=form_param.service_id,
-                duty_id=duty.id,
                 company_id=token.company_id,
-                ticket=ticket_data,
+                ticket={
+                    "sequence_id": ticket.sequence_id,
+                    "created_on": ticket.created_on.isoformat(),
+                    "ticket_types": [
+                        tt.model_dump(mode="json") for tt in ticket.ticket_types
+                    ],
+                    "pickup_point": ticket.pickup_point,
+                    "dropping_point": ticket.dropping_point,
+                    "extras": extras,
+                },
                 amount=ticket.amount,
             )
+            if warnings:
+                paper_ticket.ticket["warnings"] = [w.value for w in warnings]
+            if token.operator_id != ticket.operator_id:
+                paper_ticket.ticket["uploaded_by"] = token.operator_id
             session.add(paper_ticket)
             paper_tickets.append(paper_ticket)
+
+        if service.status != ServiceStatus.STARTED:
+            service.status = ServiceStatus.STARTED
 
         session.commit()
         for paper_ticket in paper_tickets:
             session.refresh(paper_ticket)
-
         return jsonable_encoder(paper_tickets)
     finally:
         release_lock(service_lock)

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -201,8 +201,8 @@ def create_paper_ticket(
             distance = (
                 dropping_point.distance_from_start - pickup_point.distance_from_start
             )
-            if distance < 0:
-                raise exceptions.UnknownValue("dropping_point")
+            if distance <= 0:
+                raise exceptions.InvalidValue("dropping_point")
 
             # Validate each ticket type and calculate fare
             total_fare = Decimal(0)

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -142,7 +142,7 @@ def create_paper_ticket(
 
     Raises:
         exceptions.UnknownValue: If the service ID does not correspond to a valid service for the operator's company, or if required landmarks are missing.
-        exceptions.InactiveResource: If a resource state prevents ticket creation.
+        exceptions.InvalidValue: If there are duplicate sequence IDs, or if the ticket amount does not match the calculated fare.
         exceptions.UnknownTicketType: If any ticket type ID in the input does not match the ticket types defined in the service fare configuration.
 
     Returns:
@@ -220,6 +220,8 @@ def create_paper_ticket(
                     )
                 )
                 total_fare += expected_price * ticket_type.count
+                if total_fare != ticket.amount:
+                    raise exceptions.InvalidValue(PaperTicket.amount)
 
             # Check for amount mismatch and operator mismatch, but do not abort the process,
             # instead, record warnings and uploaded_by info in the ticket payload
@@ -234,8 +236,6 @@ def create_paper_ticket(
             )
             if operator is None:
                 warnings.append(PaperTicketWarning.OPERATOR_NOT_FOUND)
-            if total_fare != ticket.amount:
-                warnings.append(PaperTicketWarning.AMOUNT_MISMATCH)
             if token.operator_id != ticket.operator_id:
                 warnings.append(PaperTicketWarning.OPERATOR_MISMATCH)
 
@@ -363,6 +363,7 @@ POST_EXCEPTIONS = [
     exceptions.InvalidToken(),
     exceptions.NoPermission(),
     exceptions.UnknownValue(PaperTicket.service_id),
+    exceptions.InvalidValue("sequence_id"),
     exceptions.InvalidValue(PaperTicket.amount),
     exceptions.UnknownTicketType(),
     exceptions.InvalidFareFunction(),
@@ -385,13 +386,12 @@ POST_DESCRIPTION = (
     .add_line(
         "Logged-in operator must have `company.service.ticket.create` permission."
     )
-    .add_line("Service must belong to the operator's company.")
     .add_line("Supports batch uploads")
     .add_line(
         "Each ticket may specify its own `operator_id` and will be processed individually."
     )
     .add_line(
-        "If an operator is not found, the ticket is attached to an orphaned duty (operator_id = NULL)."
+        "If an operator is not found, the ticket is attached to an orphaned duty."
     )
     .add_line(
         "If a duty is ENDED, it is reactivated to STARTED with `finished_on` cleared."
@@ -400,15 +400,15 @@ POST_DESCRIPTION = (
         "Ticket pickup/dropping points are validated against service landmarks (batch-validated)."
     )
     .add_line("Ticket fares are validated server-side using the service fare function.")
-    .add_line(
-        "Amount mismatches do NOT abort the batch; a `AMOUNT_MISMATCH` warning is added to the ticket payload."
-    )
+    .add_line("Amount mismatches will raise an `InvalidValue` exception.")
     .add_line(
         "If `ticket.operator_id` differs from the uploader, an `OPERATOR_MISMATCH` warning is added and `uploaded_by` records the uploader."
     )
     .add_line(
-        "If there are no warnings, `warnings` will be an empty list. If there is no operator mismatch, `uploaded_by` will be null."
+        "If no warnings are generated, `warnings` will be empty. `uploaded_by` is only populated when an operator mismatch occurs."
     )
+    .add_line("A maximum of 50 tickets can be created in a single batch upload.")
+    .add_line("Duplicate sequence IDs within the same batch are not allowed.")
 )
 
 GET_DESCRIPTION = Description().add_head("Fetches a list of paper tickets.")

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -281,6 +281,7 @@ def create_paper_ticket(
             # Create paper ticket with warnings and uploaded_by info if applicable
             paper_ticket = PaperTicket(
                 service_id=form_param.service_id,
+                duty_id=duty.id,
                 company_id=token.company_id,
                 ticket={
                     "sequence_id": ticket.sequence_id,

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -45,7 +45,7 @@ from app.src.filters import PaginationFilter, IDFilter, CreatedOnFilter
 from app.src import exceptions
 from app.src.redis import acquire_lock, release_lock
 from app.src.dynamic_fare import v1
-from app.src.digital_ticket.v1 import TicketSchema, TicketTypeSchema, TwoDecimalPlaces
+from app.src.digital_ticket.v1 import TwoDecimalPlaces
 from app.api.service import construct_service_transition_lock
 from app.src.enums import PaperTicketWarning
 
@@ -274,6 +274,7 @@ def create_paper_ticket(
                         Duty.operator_id == duty_operator_id,
                         Duty.status.in_((DutyStatus.STARTED, DutyStatus.ENDED)),
                     )
+                    .order_by(Duty.id.desc())
                     .first()
                 )
 

--- a/app/src/db.py
+++ b/app/src/db.py
@@ -2548,7 +2548,7 @@ class PaperTicket(ORMbase):
                 - `pickup_point`: Starting landmark ID of the passenger.
                 - `dropping_point`: Ending landmark ID of the passenger.
                 - `extras`: Any additional information relevant to the ticket.
-                - `warning`: Optional field for any warnings related to the ticket. Mapped from the `PaperTicketWarning` enum.
+                - `warnings`: Optional field for any warnings related to the ticket. Mapped from the `PaperTicketWarning` enum.
                 - `uploaded_by`: Optional operator ID of the person who uploaded the ticket, if different from the duty operator.
                 - `created_on`: Timestamp of when the ticket was created at client side.
 

--- a/app/src/db.py
+++ b/app/src/db.py
@@ -2541,11 +2541,16 @@ class PaperTicket(ORMbase):
             Indicates the company under which the ticket was issued.
 
         ticket (JSONB, not null):
-            Structured data capturing the ticket details including operator_id,
-            sequence_id, created_on, ticket_types, pickup_point, dropping_point,
-            extras, and optional warning metadata. For operator mismatches,
-            `uploaded_by` stores the uploader's operator ID. It is closely bound
-            to `ticket_type` in fare attributes.
+            Structured data capturing the ticket details.
+            Expected keys and values:
+                - `sequence_id`: Unique identifier for the ticket generated at the client side.
+                - `ticket_types`: List of ticket types.
+                - `pickup_point`: Starting landmark ID of the passenger.
+                - `dropping_point`: Ending landmark ID of the passenger.
+                - `extras`: Any additional information relevant to the ticket.
+                - `warning`: Optional field for any warnings related to the ticket. Mapped from the `PaperTicketWarning` enum.
+                - `uploaded_by`: Optional operator ID of the person who uploaded the ticket, if different from the duty operator.
+                - `created_on`: Timestamp of when the ticket was created at client side.
 
         amount (Numeric(10, 2), not null):
             Total fare amount collected for this ticket.

--- a/app/src/db.py
+++ b/app/src/db.py
@@ -2541,9 +2541,11 @@ class PaperTicket(ORMbase):
             Indicates the company under which the ticket was issued.
 
         ticket (JSONB, not null):
-            Structured data capturing the full ticket content including ticket types,
-            pickup_point, dropping_point, and any additional metadata.
-            It is closely bound to `ticket_type` in fare attributes.
+            Structured data capturing the ticket details including operator_id,
+            sequence_id, created_on, ticket_types, pickup_point, dropping_point,
+            extras, and optional warning metadata. For operator mismatches,
+            `uploaded_by` stores the uploader's operator ID. It is closely bound
+            to `ticket_type` in fare attributes.
 
         amount (Numeric(10, 2), not null):
             Total fare amount collected for this ticket.

--- a/app/src/digital_ticket/v1.py
+++ b/app/src/digital_ticket/v1.py
@@ -17,7 +17,7 @@ TwoDecimalPlaces = Annotated[Decimal, Field(max_digits=10, decimal_places=2, ge=
 
 
 # Schema definitions for ticket data
-class TicketType(BaseModel):
+class TicketTypeSchema(BaseModel):
     id: int = Field(ge=1, le=255)
     count: int = Field(ge=1, le=255)
     price: TwoDecimalPlaces
@@ -27,7 +27,7 @@ class TicketSchema(BaseModel):
     id: int
     service_id: int
     created_on: datetime
-    ticket_types: List[TicketType]
+    ticket_types: List[TicketTypeSchema]
     amount: TwoDecimalPlaces
     pickup_point: int
     dropping_point: int

--- a/app/src/enums.py
+++ b/app/src/enums.py
@@ -201,3 +201,11 @@ class FareScope(IntEnum):
 
     GLOBAL = 1
     LOCAL = 2
+
+
+class PaperTicketWarning(StrEnum):
+    """Warnings associated with a paper ticket upload."""
+
+    OPERATOR_NOT_FOUND = "OPERATOR_NOT_FOUND"
+    AMOUNT_MISMATCH = "AMOUNT_MISMATCH"
+    OPERATOR_MISMATCH = "OPERATOR_MISMATCH"

--- a/app/src/enums.py
+++ b/app/src/enums.py
@@ -203,8 +203,8 @@ class FareScope(IntEnum):
     LOCAL = 2
 
 
-class PaperTicketWarning(StrEnum):
+class PaperTicketWarning(IntEnum):
     """Warnings associated with a paper ticket upload."""
 
-    OPERATOR_NOT_FOUND = "OPERATOR_NOT_FOUND"
-    OPERATOR_MISMATCH = "OPERATOR_MISMATCH"
+    OPERATOR_NOT_FOUND = 1
+    OPERATOR_MISMATCH = 2

--- a/app/src/enums.py
+++ b/app/src/enums.py
@@ -207,5 +207,4 @@ class PaperTicketWarning(StrEnum):
     """Warnings associated with a paper ticket upload."""
 
     OPERATOR_NOT_FOUND = "OPERATOR_NOT_FOUND"
-    AMOUNT_MISMATCH = "AMOUNT_MISMATCH"
     OPERATOR_MISMATCH = "OPERATOR_MISMATCH"

--- a/app/src/exceptions.py
+++ b/app/src/exceptions.py
@@ -250,7 +250,9 @@ class InvalidValue(APIException):
     status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
     headers = {"X-Error": "InvalidValue"}
 
-    def __init__(self, column: InstrumentedAttribute):
+    def __init__(self, column: Union[InstrumentedAttribute, str]):
+        if isinstance(column, str):
+            column = type("Column", (), {"name": column})()
         detail = f"Invalid {column.name} is provided"
         super().__init__(detail=detail)
 


### PR DESCRIPTION
### **Summary of Changes**
- Added batch paper ticket upload support.
- Added validation for duplicate sequence_id values within a batch.
- Created/reused duties for tickets in the batch using duty caching.
- Added warning handling for OPERATOR_NOT_FOUND and OPERATOR_MISMATCH without rejecting the batch.
- Stored ticket warnings in the ticket payload for later review.

### **How to Test / Verify**

- Upload a batch of valid tickets and verify all tickets are created successfully.
- Upload a batch containing tickets with invalid operators and verify tickets are created with OPERATOR_NOT_FOUND warnings.
- Upload a batch containing operator mismatches and verify tickets are created with OPERATOR_MISMATCH warnings.
- Upload multiple tickets for the same operator and verify the same duty is reused.
- Upload a batch with duplicate sequence_id values and verify validation fails.

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
N/A
