### PR TITLE
Enforce maximum vehicle limit per company in vehicle creation

### DIFF
--- a/app/api/vehicle.py
+++ b/app/api/vehicle.py
@@ -29,7 +29,7 @@ from app.src.enums import (
     OrderIn,
     VehicleStatus,
 )
-from app.src.constants import TMZ_PRIMARY
+from app.src.constants import MAX_VEHICLES_PER_COMPANY, TMZ_PRIMARY
 from app.src.permissions.executive import PermissionPath as ExecutivePermissionPath
 from app.src.permissions.operator import PermissionPath as OperatorPermissionPath
 from app.src import exceptions
@@ -259,6 +259,14 @@ def create_vehicle(session: Session, form_param: CreateForm) -> dict:
     Returns:
         dict: The created vehicle data.
     """
+    vehicle_count = (
+        session.query(Vehicle)
+        .filter(Vehicle.company_id == form_param.company_id)
+        .count()
+    )
+    if vehicle_count >= MAX_VEHICLES_PER_COMPANY:
+        raise exceptions.LimitExceeded(Vehicle)
+
     validate_manufactured_on(form_param)
     vehicle = Vehicle(
         company_id=form_param.company_id,
@@ -436,6 +444,7 @@ POST_EXCEPTIONS = [
     exceptions.InvalidToken(),
     exceptions.NoPermission(),
     exceptions.InvalidValue(Vehicle.manufactured_on),
+    exceptions.LimitExceeded(Vehicle),
 ]
 
 PATCH_EXCEPTIONS = [
@@ -464,6 +473,7 @@ POST_DESCRIPTION = (
     .add_line("Duplicate registration numbers are not allowed.")
     .add_line("Manufactured date cannot be in the future.")
     .add_line("By default, the vehicle status is set to CREATED.")
+    .add_line(f"Maximum vehicles per company is limited to {MAX_VEHICLES_PER_COMPANY}.")
 )
 
 PATCH_DESCRIPTION = (

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -135,6 +135,7 @@ MIN_IMAGE_FILE_SIZE = 1 * 1024  # Minimum allowed file size in bytes (1 KB)
 MAX_ROUTES_PER_COMPANY = 100  # Maximum routes per company
 MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company
 MAX_LOCAL_FARES_PER_COMPANY = 50  # Maximum LOCAL fares per company
+MAX_VEHICLES_PER_COMPANY = 100  # Maximum vehicles per company
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
Reason for the change?
- Added validation to restrict the number of vehicles that can be created for a company. This prevents excessive vehicle creation -and helps maintain system constraints and better management.

What changed? 
- Added maximum vehicle limit(100) validation per company
- Restricted vehicle creation when the configured limit is reached

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
Test the Operator and Executive applications.
- Set MAX_VEHICLES_PER_COMPANY= 3 for easier API testing.
- Create the first 3 vehicle for the same company using the vehicle creation API.
- Verify that all 3 vehicles are created successfully.
- Attempt to create a 4th vehicle for the same company.
- Verify that the API blocks vehicle creation and returns the appropriate limit exceeded response.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
NA


### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
NA
