### PR TITLE
Remove invalid association exception to reduce complexity

### DIFF
--- a/app/api/operator_role_map.py
+++ b/app/api/operator_role_map.py
@@ -16,7 +16,6 @@ from sqlalchemy.orm.session import Session
 
 from app.api.bearer import oauth2_executive, bearer_operator
 from app.src.db import (
-    Company,
     ExecutiveToken,
     Operator,
     OperatorRole,

--- a/app/api/operator_role_map.py
+++ b/app/api/operator_role_map.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm.session import Session
 
 from app.api.bearer import oauth2_executive, bearer_operator
 from app.src.db import (
+    Company,
     ExecutiveToken,
     Operator,
     OperatorRole,
@@ -67,11 +68,23 @@ class OperatorRoleMapSchema(BaseModel):
 # ---------------------------------------------------------------------------
 ## Input Forms
 # ---------------------------------------------------------------------------
-class CreateForm(BaseModel):
-    """Form data for creating a new operator role mapping."""
+class CreateFormForOP(BaseModel):
+    """Form data for creating a new operator role mapping for an operator."""
 
     role_id: int = Field()
     operator_id: int = Field()
+
+
+class CreateFormForEX(CreateFormForOP):
+    """Form data for creating a new operator role mapping for an executive."""
+
+    company_id: int = Field()
+
+
+class CreateForm(CreateFormForEX):
+    """Generic combined form data for creating a new operator role mapping."""
+
+    pass
 
 
 class UpdateForm(BaseModel):
@@ -138,7 +151,6 @@ def create_role_map(
     Raises:
         exceptions.UnknownValue: If the specified role_id or operator_id does not exist
             or does not satisfy the respective filter condition.
-        exceptions.InvalidAssociation: If the specified role and operator do not belong to the same company.
     """
     operator = validate_id(
         session,
@@ -154,13 +166,9 @@ def create_role_map(
         OperatorRoleMap.role_id,
         extra_filter=extra_filter_for_role,
     )
-    if role.company_id != operator.company_id:
-        raise exceptions.InvalidAssociation(
-            OperatorRoleMap.role_id, OperatorRoleMap.operator_id
-        )
 
     role_map = OperatorRoleMap(
-        role_id=role.id, operator_id=operator.id, company_id=operator.company_id
+        role_id=role.id, operator_id=operator.id, company_id=form_param.company_id
     )
     session.add(role_map)
     session.commit()
@@ -191,9 +199,7 @@ def update_role_map(
 
      Raises:
         exceptions.UnknownValue: If the specified role_id does not exist or does not satisfy the role_filter condition.
-        exceptions.InvalidAssociation: If the new role does not belong to the same company as the operator.
     """
-
     role_map = validate_id(
         session,
         OperatorRoleMap,
@@ -203,18 +209,14 @@ def update_role_map(
     )
 
     if form_param.role_id is not None and role_map.role_id != form_param.role_id:
-        role = validate_id(
+        operator_role = validate_id(
             session,
             OperatorRole,
             form_param.role_id,
             OperatorRoleMap.role_id,
             extra_filter=extra_filter_for_role,
         )
-        if role.company_id != role_map.company_id:
-            raise exceptions.InvalidAssociation(
-                OperatorRoleMap.role_id, OperatorRoleMap.operator_id
-            )
-        role_map.role_id = form_param.role_id
+        role_map.role_id = operator_role.id
 
     have_updates = session.is_modified(role_map)
     if have_updates:
@@ -292,7 +294,6 @@ POST_EXCEPTIONS = [
     exceptions.NoPermission(),
     exceptions.UnknownValue(OperatorRoleMap.operator_id),
     exceptions.UnknownValue(OperatorRoleMap.role_id),
-    exceptions.InvalidAssociation(OperatorRoleMap.role_id, OperatorRoleMap.operator_id),
 ]
 
 PATCH_EXCEPTIONS = [
@@ -300,7 +301,6 @@ PATCH_EXCEPTIONS = [
     exceptions.NoPermission(),
     exceptions.UnknownValue(OperatorRoleMap.id),
     exceptions.UnknownValue(OperatorRoleMap.role_id),
-    exceptions.InvalidAssociation(OperatorRoleMap.role_id, OperatorRoleMap.operator_id),
 ]
 
 DELETE_EXCEPTIONS = [
@@ -355,11 +355,14 @@ GET_DESCRIPTION = Description().add_head("Fetches a list of operator role mappin
         .add_line(
             "Logged-in executive must have `company.operator.role.update` permission."
         )
+        .add_line(
+            "`company_id` is required and used to validate operator and role ownership."
+        )
         .to_string()
     ),
 )
 async def create_operator_role_map_for_executive(
-    form_param: CreateForm,
+    form_param: CreateFormForEX,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
 ):
@@ -371,7 +374,12 @@ async def create_operator_role_map_for_executive(
             [ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR_ROLE],
         )
 
-        role_map_data = create_role_map(session, form_param)
+        role_map_data = create_role_map(
+            session,
+            CreateForm(**form_param.model_dump()),
+            extra_filter_for_operator=(Operator.company_id == form_param.company_id),
+            extra_filter_for_role=(OperatorRole.company_id == form_param.company_id),
+        )
         log_event(token, request_info, role_map_data)
         return role_map_data
     except Exception as e:
@@ -409,10 +417,20 @@ async def update_operator_role_map_for_executive(
             [ExecutivePermissionPath.UPDATE_COMPANY_OPERATOR_ROLE],
         )
 
+        role_map = validate_id(
+            session,
+            OperatorRoleMap,
+            id,
+            OperatorRoleMap.id,
+        )
         have_updates, role_map_data = update_role_map(
             session,
             id,
             form_param,
+            extra_filter_for_role_map=(
+                OperatorRoleMap.company_id == role_map.company_id
+            ),
+            extra_filter_for_role=(OperatorRole.company_id == role_map.company_id),
         )
         if have_updates:
             log_event(token, request_info, role_map_data)
@@ -507,7 +525,7 @@ async def fetch_operator_role_maps_for_executive(
     ),
 )
 async def create_operator_role_map_for_operator(
-    form_param: CreateForm,
+    form_param: CreateFormForOP,
     access_token=Depends(bearer_operator),
     request_info=Depends(get_request_info),
 ):
@@ -521,7 +539,7 @@ async def create_operator_role_map_for_operator(
 
         role_map_data = create_role_map(
             session,
-            form_param,
+            CreateForm(**form_param.model_dump(), company_id=token.company_id),
             extra_filter_for_operator=(Operator.company_id == token.company_id),
             extra_filter_for_role=(OperatorRole.company_id == token.company_id),
         )

--- a/app/api/service.py
+++ b/app/api/service.py
@@ -170,8 +170,8 @@ class PrivateServiceSchema(PublicServiceSchema):
 # ---------------------------------------------------------------------------
 ## Input Forms
 # ---------------------------------------------------------------------------
-class CreateForm(BaseModel):
-    """Form data for creating a new service."""
+class CreateFormForOP(BaseModel):
+    """Form data for creating a new service for an operator."""
 
     route_id: int = Field()
     fare_id: int = Field()
@@ -183,6 +183,18 @@ class CreateForm(BaseModel):
         description=enum_str(TicketingMode), default=TicketingMode.HYBRID
     )
     starting_at: datetime = Field()
+
+
+class CreateFormForEX(CreateFormForOP):
+    """Form data for creating a new service for an executive."""
+
+    company_id: int = Field()
+
+
+class CreateForm(CreateFormForEX):
+    """Generic combined form data for creating a new service."""
+
+    pass
 
 
 class UpdateForm(BaseModel):
@@ -606,12 +618,17 @@ def create_service(
     Raises:
         exceptions.InactiveResource: If the vehicle, company, or route is not active/verified/valid.
         exceptions.InvalidValue: If the starting date is not valid.
-        exceptions.InvalidAssociation: If there are invalid associations between vehicle, route, fare, and company.
     """
     service_overlapping_lock = None
     fare_lock = None
     vehicle_lock = None
     try:
+        company = validate_id(
+            session,
+            Company,
+            form_param.company_id,
+            Service.company_id,
+        )
         vehicle = validate_id(
             session,
             Vehicle,
@@ -634,21 +651,6 @@ def create_service(
             extra_filter=extra_filter_for_fare,
         )
 
-        if vehicle.company_id != route.company_id:
-            raise exceptions.InvalidAssociation(
-                VehicleInService.vehicle_id, LandmarkInRoute.route_id
-            )
-        if fare.scope != FareScope.GLOBAL:
-            if fare.company_id != vehicle.company_id:
-                raise exceptions.InvalidAssociation(
-                    FareInService.fare_id, VehicleInService.vehicle_id
-                )
-        company = validate_id(
-            session,
-            Company,
-            vehicle.company_id,
-            Service.company_id,
-        )
         # validations
         if vehicle.status != VehicleStatus.ACTIVE:
             raise exceptions.InactiveResource(Vehicle)
@@ -818,10 +820,6 @@ def update_service(
                 "vehicle_id",
                 extra_filter=extra_filter_for_vehicle,
             )
-            if vehicle.company_id != service.company_id:
-                raise exceptions.InvalidAssociation(
-                    VehicleInService.vehicle_id, Service.company_id
-                )
         if "route_id" in update_data:
             route = validate_id(
                 session,
@@ -830,10 +828,6 @@ def update_service(
                 "route_id",
                 extra_filter=extra_filter_for_route,
             )
-            if route.company_id != service.company_id:
-                raise exceptions.InvalidAssociation(
-                    LandmarkInRoute.route_id, Service.company_id
-                )
         if "fare_id" in update_data:
             fare = validate_id(
                 session,
@@ -842,10 +836,6 @@ def update_service(
                 "fare_id",
                 extra_filter=extra_filter_for_fare,
             )
-            if fare.scope != FareScope.GLOBAL and fare.company_id != service.company_id:
-                raise exceptions.InvalidAssociation(
-                    FareInService.fare_id, Service.company_id
-                )
         _allowed_service_status_transitions = {
             ServiceStatus.CREATED: [ServiceStatus.CACHED],
             ServiceStatus.CACHED: [ServiceStatus.ENDED],
@@ -1260,10 +1250,6 @@ POST_EXCEPTIONS = [
     exceptions.OverlappingService(),
     exceptions.InvalidValue(Service.starting_at),
     exceptions.UnknownValue(Service.company_id),
-    exceptions.InvalidAssociation(
-        VehicleInService.vehicle_id, LandmarkInRoute.route_id
-    ),
-    exceptions.InvalidAssociation(FareInService.fare_id, VehicleInService.vehicle_id),
     exceptions.LockAcquireTimeout(),
 ]
 
@@ -1280,9 +1266,6 @@ PATCH_EXCEPTIONS = [
     exceptions.OverlappingService(),
     exceptions.DataInUse(Service),
     exceptions.InvalidValue(Service.starting_at),
-    exceptions.InvalidAssociation(VehicleInService.vehicle_id, Service.company_id),
-    exceptions.InvalidAssociation(LandmarkInRoute.route_id, Service.company_id),
-    exceptions.InvalidAssociation(FareInService.fare_id, Service.company_id),
     exceptions.LockAcquireTimeout(),
 ]
 
@@ -1375,10 +1358,13 @@ GET_DETAIL_DESCRIPTION = Description().add_head("Fetch service details by ID.")
     responses=fuse_exception_responses(POST_EXCEPTIONS),
     description=POST_DESCRIPTION.copy()
     .add_line("Logged in executive must have `company.service.create` permission.")
+    .add_line(
+        "`company_id` is required and used to validate route, fare, and vehicle ownership."
+    )
     .to_string(),
 )
 async def create_service_for_executive(
-    form_param: CreateForm,
+    form_param: CreateFormForEX,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
 ):
@@ -1387,9 +1373,14 @@ async def create_service_for_executive(
         token = authorize_executive(
             session, access_token, [ExecutivePermissionPath.CREATE_COMPANY_SERVICE]
         )
+
         service_data = create_service(
             session,
             form_param,
+            extra_filter_for_route=(Route.company_id == form_param.company_id),
+            extra_filter_for_vehicle=(Vehicle.company_id == form_param.company_id),
+            extra_filter_for_fare=(Fare.company_id == form_param.company_id)
+            | (Fare.scope == FareScope.GLOBAL),
         )
         log_event(token, request_info, service_data)
         return service_data
@@ -1421,10 +1412,16 @@ async def update_service_for_executive(
             session, access_token, [ExecutivePermissionPath.UPDATE_COMPANY_SERVICE]
         )
 
+        service = validate_id(session, Service, id, Service.id)
         have_updates, service_data = update_service(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
+            extra_filter_for_service=(Service.company_id == service.company_id),
+            extra_filter_for_route=(Route.company_id == service.company_id),
+            extra_filter_for_vehicle=(Vehicle.company_id == service.company_id),
+            extra_filter_for_fare=(Fare.company_id == service.company_id)
+            | (Fare.scope == FareScope.GLOBAL),
         )
         if have_updates:
             log_event(token, request_info, service_data)
@@ -1535,7 +1532,7 @@ async def delete_service_for_executive(
     .to_string(),
 )
 async def create_service_for_operator(
-    form_param: CreateForm,
+    form_param: CreateFormForOP,
     access_token=Depends(bearer_operator),
     request_info=Depends(get_request_info),
 ):
@@ -1549,7 +1546,7 @@ async def create_service_for_operator(
 
         service_data = create_service(
             session,
-            form_param,
+            CreateForm(**form_param.model_dump(), company_id=token.company_id),
             extra_filter_for_route=(Route.company_id == token.company_id),
             extra_filter_for_vehicle=(Vehicle.company_id == token.company_id),
             extra_filter_for_fare=(Fare.company_id == token.company_id)

--- a/app/api/service_assignment.py
+++ b/app/api/service_assignment.py
@@ -17,7 +17,6 @@ from sqlalchemy.orm.session import Session
 from app.api.bearer import bearer_operator, oauth2_executive
 from app.src import exceptions
 from app.src.db import (
-    Company,
     ExecutiveToken,
     Operator,
     OperatorToken,

--- a/app/api/service_assignment.py
+++ b/app/api/service_assignment.py
@@ -228,7 +228,7 @@ def update_service_assignment(
         form_param.operator_id is not None
         and service_assignment.operator_id != form_param.operator_id
     ):
-        operator = validate_id(
+        validate_id(
             session,
             Operator,
             form_param.operator_id,

--- a/app/api/service_assignment.py
+++ b/app/api/service_assignment.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm.session import Session
 from app.api.bearer import bearer_operator, oauth2_executive
 from app.src import exceptions
 from app.src.db import (
+    Company,
     ExecutiveToken,
     Operator,
     OperatorToken,
@@ -64,11 +65,23 @@ class ServiceAssignmentSchema(BaseModel):
 # ---------------------------------------------------------------------------
 ## Input Forms
 # ---------------------------------------------------------------------------
-class CreateForm(BaseModel):
-    """Form data for creating a service assignment."""
+class CreateFormForOP(BaseModel):
+    """Form data for creating a service assignment for an operator."""
 
     service_id: int = Field()
     operator_id: int = Field()
+
+
+class CreateFormForEX(CreateFormForOP):
+    """Form data for creating a service assignment for an executive."""
+
+    company_id: int = Field()
+
+
+class CreateForm(CreateFormForEX):
+    """Generic combined form data for creating a service assignment."""
+
+    pass
 
 
 class UpdateForm(BaseModel):
@@ -135,7 +148,6 @@ def create_service_assignment(
 
     Raises:
         exceptions.UnknownValue: If the specified service_id or operator_id does not exist.
-        exceptions.InvalidAssociation: If the service or operator do not belong to the same company.
     """
     service = validate_id(
         session,
@@ -151,12 +163,8 @@ def create_service_assignment(
         ServiceAssignment.operator_id,
         extra_filter=extra_filter_for_operator,
     )
-    if service.company_id != operator.company_id:
-        raise exceptions.InvalidAssociation(
-            ServiceAssignment.service_id, ServiceAssignment.operator_id
-        )
     service_assignment = ServiceAssignment(
-        company_id=operator.company_id,
+        company_id=service.company_id,
         service_id=service.id,
         operator_id=operator.id,
     )
@@ -208,7 +216,6 @@ def update_service_assignment(
 
     Raises:
         exceptions.UnknownValue: If the specified operator_id does not exist.
-        exceptions.InvalidAssociation: If the new operator does not belong to the same company.
     """
     service_assignment = validate_id(
         session,
@@ -229,10 +236,6 @@ def update_service_assignment(
             ServiceAssignment.operator_id,
             extra_filter=extra_filter_for_operator,
         )
-        if operator.company_id != service_assignment.company_id:
-            raise exceptions.InvalidAssociation(
-                ServiceAssignment.operator_id, ServiceAssignment.company_id
-            )
         service_assignment.operator_id = form_param.operator_id
 
     have_updates = session.is_modified(service_assignment)
@@ -314,9 +317,6 @@ POST_EXCEPTIONS = [
     exceptions.NoPermission(),
     exceptions.UnknownValue(ServiceAssignment.service_id),
     exceptions.UnknownValue(ServiceAssignment.operator_id),
-    exceptions.InvalidAssociation(
-        ServiceAssignment.service_id, ServiceAssignment.operator_id
-    ),
 ]
 
 PATCH_EXCEPTIONS = [
@@ -324,9 +324,6 @@ PATCH_EXCEPTIONS = [
     exceptions.NoPermission(),
     exceptions.UnknownValue(ServiceAssignment.id),
     exceptions.UnknownValue(ServiceAssignment.operator_id),
-    exceptions.InvalidAssociation(
-        ServiceAssignment.operator_id, ServiceAssignment.company_id
-    ),
 ]
 
 DELETE_EXCEPTIONS = [
@@ -381,11 +378,14 @@ GET_DESCRIPTION = Description().add_head("Fetches a list of service assignments.
         .add_line(
             "Logged-in executive must have `company.service.assignment.create` permission."
         )
+        .add_line(
+            "`company_id` is required and used to validate service and operator ownership."
+        )
         .to_string()
     ),
 )
 async def create_service_assignment_for_executive(
-    form_param: CreateForm,
+    form_param: CreateFormForEX,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
 ):
@@ -399,7 +399,9 @@ async def create_service_assignment_for_executive(
 
         service_assignment_data = create_service_assignment(
             session,
-            form_param,
+            CreateForm(**form_param.model_dump()),
+            extra_filter_for_service=(Service.company_id == form_param.company_id),
+            extra_filter_for_operator=(Operator.company_id == form_param.company_id),
         )
         log_event(token, request_info, service_assignment_data)
         return service_assignment_data
@@ -438,8 +440,22 @@ async def update_service_assignment_for_executive(
             [ExecutivePermissionPath.UPDATE_COMPANY_SERVICE_ASSIGNMENT],
         )
 
+        service_assignment = validate_id(
+            session,
+            ServiceAssignment,
+            id,
+            ServiceAssignment.id,
+        )
         have_updates, service_assignment_data = update_service_assignment(
-            session, id, form_param
+            session,
+            id,
+            form_param,
+            extra_filter_for_assignment=(
+                ServiceAssignment.company_id == service_assignment.company_id
+            ),
+            extra_filter_for_operator=(
+                Operator.company_id == service_assignment.company_id
+            ),
         )
         if have_updates:
             log_event(token, request_info, service_assignment_data)
@@ -542,7 +558,7 @@ async def fetch_service_assignments_for_executive(
     ),
 )
 async def create_service_assignment_for_operator(
-    form_param: CreateForm,
+    form_param: CreateFormForOP,
     access_token=Depends(bearer_operator),
     request_info=Depends(get_request_info),
 ):
@@ -556,7 +572,7 @@ async def create_service_assignment_for_operator(
 
         service_assignment_data = create_service_assignment(
             session,
-            form_param,
+            CreateForm(**form_param.model_dump(), company_id=token.company_id),
             extra_filter_for_service=(Service.company_id == token.company_id),
             extra_filter_for_operator=(Operator.company_id == token.company_id),
         )

--- a/app/api/service_automation.py
+++ b/app/api/service_automation.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm.session import Session
 from app.api.bearer import bearer_operator, oauth2_executive
 from app.src import exceptions
 from app.src.db import (
+    Company,
     ExecutiveToken,
     Fare,
     Job,
@@ -85,8 +86,8 @@ class ServiceAutomationSchema(BaseModel):
 # ---------------------------------------------------------------------------
 ## Input Forms
 # ---------------------------------------------------------------------------
-class CreateForm(BaseModel):
-    """Form data for creating a new service automation."""
+class CreateFormForOP(BaseModel):
+    """Form data for creating a new service automation for an operator."""
 
     job_id: int | None = Field(default=None)
     name: str = Field(min_length=1, max_length=128, pattern=NAME_PATTERN)
@@ -98,6 +99,18 @@ class CreateForm(BaseModel):
         description=enum_str(TicketingMode), default=TicketingMode.HYBRID
     )
     starting_at: time = Field()
+
+
+class CreateFormForEX(CreateFormForOP):
+    """Form data for creating a new service automation for an executive."""
+
+    company_id: int = Field()
+
+
+class CreateForm(CreateFormForEX):
+    """Generic combined form data for creating a new service automation."""
+
+    pass
 
 
 class UpdateForm(BaseModel):
@@ -217,23 +230,8 @@ def create_service_automation(
         extra_filter=extra_filter_for_fare,
     )
 
-    # Validations
-    if job is not None and job.company_id != route.company_id:
-        raise exceptions.InvalidAssociation(
-            ServiceAutomation.job_id, ServiceAutomation.route_id
-        )
-    if route.company_id != vehicle.company_id:
-        raise exceptions.InvalidAssociation(
-            ServiceAutomation.route_id, ServiceAutomation.vehicle_id
-        )
-    if fare.scope != FareScope.GLOBAL:
-        if fare.company_id != vehicle.company_id:
-            raise exceptions.InvalidAssociation(
-                ServiceAutomation.fare_id, ServiceAutomation.vehicle_id
-            )
-
     service_automation = ServiceAutomation(
-        company_id=route.company_id,
+        company_id=form_param.company_id,
         job_id=form_param.job_id,
         name=form_param.name,
         description=form_param.description,
@@ -287,56 +285,37 @@ def update_service_automation(
 
     update_data = form_param.model_dump(exclude_unset=True)
     if "job_id" in update_data and update_data["job_id"] is not None:
-        job = validate_id(
+        validate_id(
             session,
             Job,
             form_param.job_id,
             ServiceAutomation.job_id,
             extra_filter=extra_filter_for_job,
         )
-        if job.company_id != service_automation.company_id:
-            raise exceptions.InvalidAssociation(
-                ServiceAutomation.job_id, ServiceAutomation.company_id
-            )
     if "route_id" in update_data:
-        route = validate_id(
+        validate_id(
             session,
             Route,
             form_param.route_id,
             ServiceAutomation.route_id,
             extra_filter=extra_filter_for_route,
         )
-        if route.company_id != service_automation.company_id:
-            raise exceptions.InvalidAssociation(
-                ServiceAutomation.route_id, ServiceAutomation.company_id
-            )
     if "fare_id" in update_data:
-        fare = validate_id(
+        validate_id(
             session,
             Fare,
             form_param.fare_id,
             ServiceAutomation.fare_id,
             extra_filter=extra_filter_for_fare,
         )
-        if (
-            fare.scope != FareScope.GLOBAL
-            and fare.company_id != service_automation.company_id
-        ):
-            raise exceptions.InvalidAssociation(
-                ServiceAutomation.fare_id, ServiceAutomation.company_id
-            )
     if "vehicle_id" in update_data:
-        vehicle = validate_id(
+        validate_id(
             session,
             Vehicle,
             form_param.vehicle_id,
             ServiceAutomation.vehicle_id,
             extra_filter=extra_filter_for_vehicle,
         )
-        if vehicle.company_id != service_automation.company_id:
-            raise exceptions.InvalidAssociation(
-                ServiceAutomation.vehicle_id, ServiceAutomation.company_id
-            )
 
     update_if_changed(service_automation, update_data)
     have_updates = session.is_modified(service_automation)
@@ -446,13 +425,6 @@ POST_EXCEPTIONS = [
     exceptions.UnknownValue(ServiceAutomation.route_id),
     exceptions.UnknownValue(ServiceAutomation.fare_id),
     exceptions.UnknownValue(ServiceAutomation.vehicle_id),
-    exceptions.InvalidAssociation(ServiceAutomation.job_id, ServiceAutomation.route_id),
-    exceptions.InvalidAssociation(
-        ServiceAutomation.route_id, ServiceAutomation.vehicle_id
-    ),
-    exceptions.InvalidAssociation(
-        ServiceAutomation.fare_id, ServiceAutomation.vehicle_id
-    ),
 ]
 
 PATCH_EXCEPTIONS = [
@@ -463,18 +435,6 @@ PATCH_EXCEPTIONS = [
     exceptions.UnknownValue(ServiceAutomation.route_id),
     exceptions.UnknownValue(ServiceAutomation.fare_id),
     exceptions.UnknownValue(ServiceAutomation.vehicle_id),
-    exceptions.InvalidAssociation(
-        ServiceAutomation.job_id, ServiceAutomation.company_id
-    ),
-    exceptions.InvalidAssociation(
-        ServiceAutomation.route_id, ServiceAutomation.company_id
-    ),
-    exceptions.InvalidAssociation(
-        ServiceAutomation.fare_id, ServiceAutomation.company_id
-    ),
-    exceptions.InvalidAssociation(
-        ServiceAutomation.vehicle_id, ServiceAutomation.company_id
-    ),
 ]
 
 DELETE_EXCEPTIONS = [
@@ -526,11 +486,14 @@ GET_DESCRIPTION = Description().add_head("Fetches a list of service automations.
     description=(
         POST_DESCRIPTION.copy()
         .add_line("Logged in executive must have `company.service.create` permission.")
+        .add_line(
+            "`company_id` is required and used to validate job, route, fare, and vehicle ownership."
+        )
         .to_string()
     ),
 )
 async def create_service_automation_for_executive(
-    form_param: CreateForm,
+    form_param: CreateFormForEX,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
 ):
@@ -545,6 +508,11 @@ async def create_service_automation_for_executive(
         service_automation_data = create_service_automation(
             session,
             CreateForm(**form_param.model_dump()),
+            extra_filter_for_job=(Job.company_id == form_param.company_id),
+            extra_filter_for_route=(Route.company_id == form_param.company_id),
+            extra_filter_for_fare=(Fare.company_id == form_param.company_id)
+            | (Fare.scope == FareScope.GLOBAL),
+            extra_filter_for_vehicle=(Vehicle.company_id == form_param.company_id),
         )
         log_event(token, request_info, service_automation_data)
         return service_automation_data
@@ -580,10 +548,26 @@ async def update_service_automation_for_executive(
             [ExecutivePermissionPath.UPDATE_COMPANY_SERVICE],
         )
 
+        service_automation = validate_id(
+            session,
+            ServiceAutomation,
+            id,
+            ServiceAutomation.id,
+        )
         have_updates, service_automation_data = update_service_automation(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
+            extra_filter_for_service_automation=(
+                ServiceAutomation.company_id == service_automation.company_id
+            ),
+            extra_filter_for_job=(Job.company_id == service_automation.company_id),
+            extra_filter_for_route=(Route.company_id == service_automation.company_id),
+            extra_filter_for_fare=(Fare.company_id == service_automation.company_id)
+            | (Fare.scope == FareScope.GLOBAL),
+            extra_filter_for_vehicle=(
+                Vehicle.company_id == service_automation.company_id
+            ),
         )
         if have_updates:
             log_event(token, request_info, service_automation_data)
@@ -676,7 +660,7 @@ async def fetch_service_automations_for_executive(
     ),
 )
 async def create_service_automation_for_operator(
-    form_param: CreateForm,
+    form_param: CreateFormForOP,
     access_token=Depends(bearer_operator),
     request_info=Depends(get_request_info),
 ):
@@ -690,7 +674,7 @@ async def create_service_automation_for_operator(
 
         service_automation_data = create_service_automation(
             session,
-            CreateForm(**form_param.model_dump()),
+            CreateForm(**form_param.model_dump(), company_id=token.company_id),
             extra_filter_for_job=(Job.company_id == token.company_id),
             extra_filter_for_route=(Route.company_id == token.company_id),
             extra_filter_for_fare=(Fare.company_id == token.company_id)

--- a/app/api/service_automation.py
+++ b/app/api/service_automation.py
@@ -18,7 +18,6 @@ from sqlalchemy.orm.session import Session
 from app.api.bearer import bearer_operator, oauth2_executive
 from app.src import exceptions
 from app.src.db import (
-    Company,
     ExecutiveToken,
     Fare,
     Job,

--- a/app/src/exceptions.py
+++ b/app/src/exceptions.py
@@ -227,21 +227,6 @@ class UnknownValue(APIException):
         super().__init__(detail=detail)
 
 
-class InvalidAssociation(APIException):
-    """
-    Raised when an association between two columns is invalid.
-    """
-
-    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
-    headers = {"X-Error": "InvalidAssociation"}
-
-    def __init__(
-        self, column_1: InstrumentedAttribute, column_2: InstrumentedAttribute
-    ):
-        detail = f"The {column_1.name} is not associated with {column_2.name}"
-        super().__init__(detail=detail)
-
-
 class InvalidValue(APIException):
     """
     Raised when an invalid id or value is provided.

--- a/tests/executive/happy_flow.py
+++ b/tests/executive/happy_flow.py
@@ -357,7 +357,11 @@ def test_operator_role_map_endpoint(
     token_headers: dict,
 ):
     print("Creating role mapping")
-    role_map_payload = {"role_id": role_1.id, "operator_id": operator.id}
+    role_map_payload = {
+        "role_id": role_1.id,
+        "operator_id": operator.id,
+        "company_id": operator.company_id,
+    }
     response = requests.post(
         operator_role_map_url,
         headers=token_headers,
@@ -593,7 +597,11 @@ def test_service_assignment(
     token_headers: dict,
 ):
     print("Creating service assignment")
-    payload = generate_service_assignment_payload(service.id, operator_1.id)
+    payload = generate_service_assignment_payload(
+        service.id,
+        operator_1.id,
+        company_id=company.id,
+    )
     response = requests.post(
         service_assignment_url, headers=token_headers, json=payload
     )
@@ -864,7 +872,7 @@ def run_test(target_url):
     response = requests.post(
         SERVICE_URL,
         headers=admin_headers,
-        json=generate_service_payload(route.id, fare.id, vehicle.id),
+        json=generate_service_payload(route.id, fare.id, vehicle.id, company.id),
     )
     assert response.status_code == 201
     service = ServiceSchema.model_validate(response.json())
@@ -960,7 +968,7 @@ def run_test(target_url):
     # Test service creation, retrieval, updating and deletion
     test_service_endpoint(
         SERVICE_URL,
-        generate_service_payload(route.id, fare.id, vehicle.id),
+        generate_service_payload(route.id, fare.id, vehicle.id, company.id),
         admin_headers,
     )
     # Test service assignment create/update/delete

--- a/tests/inputs.py
+++ b/tests/inputs.py
@@ -220,10 +220,12 @@ def generate_landmark_in_route_payload(
     }
 
 
-def generate_service_payload(route_id: int, fare_id: int, vehicle_id: int):
+def generate_service_payload(
+    route_id: int, fare_id: int, vehicle_id: int, company_id: int | None = None
+):
     # choose a start offset in minutes (5–1439) to avoid `starting_at` == now
     minutes_offset = int(np.random.randint(5, 1440))
-    return {
+    payload = {
         "starting_at": (
             datetime.now(timezone.utc) + timedelta(minutes=minutes_offset)
         ).isoformat(),
@@ -231,13 +233,21 @@ def generate_service_payload(route_id: int, fare_id: int, vehicle_id: int):
         "fare_id": fare_id,
         "vehicle_id": vehicle_id,
     }
+    if company_id is not None:
+        payload["company_id"] = company_id
+    return payload
 
 
-def generate_service_assignment_payload(service_id: int, operator_id: int) -> dict:
-    return {
+def generate_service_assignment_payload(
+    service_id: int, operator_id: int, company_id: int | None = None
+) -> dict:
+    payload = {
         "service_id": service_id,
         "operator_id": operator_id,
     }
+    if company_id is not None:
+        payload["company_id"] = company_id
+    return payload
 
 
 # Utility function to generate a random image for testing purposes


### PR DESCRIPTION
### **Summary of Changes**
Reason for the change?

- Current endpoint validation relies on raising InvalidAssociation exceptions for invalid relationships, which creates additional complexity and inconsistent behavior across endpoints.
- Existing validation already prevents invalid associations in non-executive endpoints, making these exceptions redundant.

What changed? 

- Removed InvalidAssociation exception handling from endpoints.
- Updated association validation to rely on validate_id with extra_filter scoped by company_id.
- Made company_id mandatory in executive create forms to ensure associations are validated within the correct company scope.
- Updated executive endpoints to use scoped validation for preventing invalid associations.
- Updated documentation and exception mappings to reflect the simplified validation flow.

### **How to Test / Verify**

1. Create endpoints with valid associations and verify requests succeed.
2. Attempt to provide an association from a different company and verify validation rejects the request through scoped validate_id.
3. Test executive create endpoints with:

- A valid company_id and matching associations → should succeed.
- Missing company_id → should fail validation.
- Associations outside the provided company_id scope → should fail validation.

4. Verify that no endpoints raise InvalidAssociation exceptions and the updated validation behavior is consistent.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
N/A


### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
