### PR TITLE
Enforce maximum trace limit per company in trace creation

### DIFF
--- a/app/api/trace.py
+++ b/app/api/trace.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 
 from app.src.db import Company, ExecutiveToken, OperatorToken, Trace, SessionLocal
 from app.src.description import Description
+from app.src.constants import MAX_TRACES_PER_COMPANY
 from app.src import exceptions
 from app.src.enums import OrderIn
 from app.src.filters import (
@@ -142,6 +143,14 @@ def create_trace(session: Session, form_param: CreateForm) -> dict:
     Returns:
         dict: The created trace data.
     """
+    trace_count = (
+        session.query(Trace)
+        .filter(Trace.company_id == form_param.company_id)
+        .count()
+    )
+    if trace_count >= MAX_TRACES_PER_COMPANY:
+        raise exceptions.LimitExceeded(Trace)
+
     trace = Trace(
         company_id=form_param.company_id,
         name=form_param.name,
@@ -253,6 +262,7 @@ def search_trace(session: Session, query_params: QueryParams) -> List[Trace]:
 POST_EXCEPTIONS = [
     exceptions.InvalidToken(),
     exceptions.NoPermission(),
+    exceptions.LimitExceeded(Trace),
 ]
 
 PATCH_EXCEPTIONS = [
@@ -278,6 +288,7 @@ POST_DESCRIPTION = (
     Description()
     .add_head("Creates a new trace.")
     .add_line("Duplicate trace names are not allowed.")
+    .add_line(f"Maximum traces per company is limited to {MAX_TRACES_PER_COMPANY}.")
 )
 
 PATCH_DESCRIPTION = (

--- a/app/api/trace.py
+++ b/app/api/trace.py
@@ -144,9 +144,7 @@ def create_trace(session: Session, form_param: CreateForm) -> dict:
         dict: The created trace data.
     """
     trace_count = (
-        session.query(Trace)
-        .filter(Trace.company_id == form_param.company_id)
-        .count()
+        session.query(Trace).filter(Trace.company_id == form_param.company_id).count()
     )
     if trace_count >= MAX_TRACES_PER_COMPANY:
         raise exceptions.LimitExceeded(Trace)

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -136,7 +136,7 @@ MAX_ROUTES_PER_COMPANY = 100  # Maximum routes per company
 MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company
 MAX_LOCAL_FARES_PER_COMPANY = 50  # Maximum LOCAL fares per company
 MAX_VEHICLES_PER_COMPANY = 100  # Maximum vehicles per company
-MAX_TRACES_PER_COMPANY = 3  # Maximum traces per company
+MAX_TRACES_PER_COMPANY = 100  # Maximum traces per company
 
 # ---------------------------------------------------------------------------
 # Role constraints (executive/operator)

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -136,7 +136,7 @@ MAX_ROUTES_PER_COMPANY = 100  # Maximum routes per company
 MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company
 MAX_LOCAL_FARES_PER_COMPANY = 50  # Maximum LOCAL fares per company
 MAX_VEHICLES_PER_COMPANY = 100  # Maximum vehicles per company
-
+MAX_TRACES_PER_COMPANY = 3  # Maximum traces per company
 
 # ---------------------------------------------------------------------------
 # Role constraints (executive/operator)

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -84,6 +84,8 @@ MAX_LANDMARK_UPDATE_DISTANCE = 1000  # 1 km
 MIN_LANDMARKS_PER_ROUTE = 2  # Minimum number of landmarks per route
 MAX_LANDMARKS_PER_ROUTE = 100  # # Maximum number of landmarks per route
 MAX_ROUTE_DISTANCE = 10000 * 1000  # Maximum  route length in meters (10000 km)
+
+
 # ---------------------------------------------------------------------------
 # Service/duty constraints
 # ---------------------------------------------------------------------------
@@ -120,6 +122,7 @@ LOCK_MAX_WAIT_SECONDS = 10
 # ---------------------------------------------------------------------------
 DYNAMIC_FARE_VERSION = 1  # Current dynamic fare version
 
+
 # ---------------------------------------------------------------------------
 # Image constants
 # ---------------------------------------------------------------------------
@@ -137,6 +140,7 @@ MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company
 MAX_LOCAL_FARES_PER_COMPANY = 50  # Maximum LOCAL fares per company
 MAX_VEHICLES_PER_COMPANY = 100  # Maximum vehicles per company
 MAX_TRACES_PER_COMPANY = 100  # Maximum traces per company
+
 
 # ---------------------------------------------------------------------------
 # Role constraints (executive/operator)


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
Reason for the change?
- Added validation to restrict the number of traces that can be created for a company. This prevents excessive trace creation -and helps maintain system constraints and better management.

What changed? 

- Added maximum trace limit(100) validation per company
- Restricted trace creation when the configured limit is reached

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Set MAX_TRACES_PER_COMPANY= 3 for easier API testing.
- Create the first 3 traces for the same company using the trace creation API.
- Verify that all 3 traces are created successfully.
- Attempt to create a 4th trace for the same company.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
NA

### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
NA