### PR TITLE
Code refactoring and standardising

### DIFF
--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -255,11 +255,11 @@ def update_bus_stop(
         update_data.pop("location")
 
     update_if_changed(bus_stop, update_data)
-    have_updates = session.is_modified(bus_stop)
-    if have_updates:
+    updated = session.is_modified(bus_stop)
+    if updated:
         session.commit()
         session.refresh(bus_stop)
-    return have_updates, bus_stop_to_dict(bus_stop)
+    return updated, bus_stop_to_dict(bus_stop)
 
 
 def search_bus_stops(session: Session, query_params: QueryParams) -> List[BusStop]:

--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -238,7 +238,9 @@ def update_bus_stop(
         form_param (UpdateForm): Form data for updating the bus stop.
 
     Returns:
-        tuple[bool, dict]: A tuple containing a boolean indicating if updates were made and the updated bus stop data with location in WKT format.
+        Tuple[bool, dict]:
+            - bool: True if the bus stop was modified and the changes were committed.
+            - dict: JSON-encoded representation of the updated bus stop.
     """
     bus_stop = validate_id(session, BusStop, id, BusStop.id)
 
@@ -249,8 +251,7 @@ def update_bus_stop(
             session, form_param.location, bus_stop.landmark_id
         )
         if new_location_geom.wkt != old_location_geom.wkt:
-            location = wkt.dumps(new_location_geom)
-            bus_stop.location = location
+            bus_stop.location = wkt.dumps(new_location_geom)
         update_data.pop("location")
 
     update_if_changed(bus_stop, update_data)
@@ -329,7 +330,9 @@ def delete_bus_stop(session: Session, id: int) -> tuple[bool, dict]:
         id (int): ID of the bus stop to delete.
 
     Returns:
-        tuple[bool, dict]: A tuple containing a boolean indicating if the bus stop was deleted and the deleted bus stop data.
+        Tuple[bool, dict]:
+            - bool: True if the bus stop was found and deleted, False otherwise.
+            - dict: JSON-encoded representation of the deleted bus stop, or an empty dictionary if not found.
     """
     bus_stop = session.query(BusStop).filter(BusStop.id == id).first()
     if bus_stop is not None:

--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -144,7 +144,9 @@ class QueryParams(
     )
 
 
-# Function
+# ---------------------------------------------------------------------------
+## Helper Functions
+# ---------------------------------------------------------------------------
 def validate_location(session: Session, location_wkt: str, landmark_id: int) -> Point:
     """
     Validate a bus stop location geometry. This function takes a WKT string representing a point
@@ -174,6 +176,89 @@ def validate_location(session: Session, location_wkt: str, landmark_id: int) -> 
         raise exceptions.BusStopOutsideLandmark()
 
     return location_geom
+
+
+def bus_stop_to_dict(bus_stop: BusStop) -> dict:
+    """
+    Convert a BusStop SQLAlchemy model instance to a dictionary with location in WKT format.
+
+    Args:
+        bus_stop (BusStop): BusStop model instance.
+
+    Returns:
+        dict: Dictionary representation of the bus stop with location in WKT format.
+    """
+    bus_stop_data = jsonable_encoder(bus_stop, exclude={BusStop.location.name})
+    bus_stop_data[BusStop.location.name] = (
+        wkb.loads(bytes(bus_stop.location.data))
+    ).wkt
+    return bus_stop_data
+
+
+# ---------------------------------------------------------------------------
+## Core Functions
+# ---------------------------------------------------------------------------
+def create_bus_stop(session: Session, form_param: CreateForm) -> dict:
+    """
+    Create a new bus stop in the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        form_param (CreateForm): Form data for creating a new bus stop.
+
+    Returns:
+        dict: Created bus stop data with location in WKT format.
+    """
+    # Validate location (WKT, SRID, and landmark boundary)
+    location_geom = validate_location(
+        session, form_param.location, form_param.landmark_id
+    )
+    location = wkt.dumps(location_geom)
+
+    bus_stop = BusStop(
+        name=form_param.name,
+        landmark_id=form_param.landmark_id,
+        location=location,
+    )
+    session.add(bus_stop)
+    session.commit()
+    session.refresh(bus_stop)
+    return bus_stop_to_dict(bus_stop)
+
+
+def update_bus_stop(
+    session: Session, id: int, form_param: UpdateForm
+) -> tuple[bool, dict]:
+    """
+    Update an existing bus stop in the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        id (int): ID of the bus stop to update.
+        form_param (UpdateForm): Form data for updating the bus stop.
+
+    Returns:
+        tuple[bool, dict]: A tuple containing a boolean indicating if updates were made and the updated bus stop data with location in WKT format.
+    """
+    bus_stop = validate_id(session, BusStop, id, BusStop.id)
+
+    update_data = form_param.model_dump(exclude_unset=True)
+    if "location" in update_data:
+        old_location_geom = wkb.loads(bytes(bus_stop.location.data))
+        new_location_geom = validate_location(
+            session, form_param.location, bus_stop.landmark_id
+        )
+        if new_location_geom.wkt != old_location_geom.wkt:
+            location = wkt.dumps(new_location_geom)
+            bus_stop.location = location
+        update_data.pop("location")
+
+    update_if_changed(bus_stop, update_data)
+    have_updates = session.is_modified(bus_stop)
+    if have_updates:
+        session.commit()
+        session.refresh(bus_stop)
+    return have_updates, bus_stop_to_dict(bus_stop)
 
 
 def search_bus_stops(session: Session, query_params: QueryParams) -> List[BusStop]:
@@ -231,16 +316,28 @@ def search_bus_stops(session: Session, query_params: QueryParams) -> List[BusSto
     query = query.order_by(ordering_func())
     query = query.offset(query_params.offset).limit(query_params.limit)
 
-    query = query.with_entities(
-        BusStop, func.ST_AsText(BusStop.location).label("location_wkt")
-    )
-    results = query.all()
-    bus_stops = []
-    for bus_stop_obj, location_wkt in results:
-        bus_stop_obj.location = location_wkt
-        bus_stops.append(bus_stop_obj)
-
+    bus_stops = query.all()
     return bus_stops
+
+
+def delete_bus_stop(session: Session, id: int) -> tuple[bool, dict]:
+    """
+    Delete a bus stop from the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        id (int): ID of the bus stop to delete.
+
+    Returns:
+        tuple[bool, dict]: A tuple containing a boolean indicating if the bus stop was deleted and the deleted bus stop data.
+    """
+    bus_stop = session.query(BusStop).filter(BusStop.id == id).first()
+    if bus_stop is not None:
+        bus_stop_data = bus_stop_to_dict(bus_stop)
+        session.delete(bus_stop)
+        session.commit()
+        return True, bus_stop_data
+    return False, {}
 
 
 # ---------------------------------------------------------------------------
@@ -340,25 +437,7 @@ async def create_bus_stop_for_executive(
             [PermissionPath.CREATE_BUS_STOP],
         )
 
-        # Validate location (WKT, SRID, and landmark boundary)
-        location_geom = validate_location(
-            session, form_param.location, form_param.landmark_id
-        )
-        validated_location = wkt.dumps(location_geom)
-
-        bus_stop = BusStop(
-            name=form_param.name,
-            landmark_id=form_param.landmark_id,
-            location=validated_location,
-        )
-        session.add(bus_stop)
-        session.commit()
-        session.refresh(bus_stop)
-
-        bus_stop_data = jsonable_encoder(bus_stop, exclude={BusStop.location.name})
-        bus_stop_data[BusStop.location.name] = (
-            wkb.loads(bytes(bus_stop.location.data))
-        ).wkt
+        bus_stop_data = create_bus_stop(session, form_param)
         log_event(token, request_info, bus_stop_data)
         return bus_stop_data
     except Exception as e:
@@ -389,31 +468,8 @@ async def update_bus_stop_for_executive(
             [PermissionPath.UPDATE_BUS_STOP],
         )
 
-        bus_stop = validate_id(session, BusStop, id, BusStop.id)
-
-        update_data = form_param.model_dump(exclude_unset=True)
-        if form_param.location is not None:
-            # Validate location if changed
-            new_geom = validate_location(
-                session, form_param.location, bus_stop.landmark_id
-            )
-            old_geom = wkb.loads(bytes(bus_stop.location.data))
-
-            if new_geom.wkt != old_geom.wkt:
-                bus_stop.location = wkt.dumps(new_geom)
-            update_data.pop("location")
-
-        update_if_changed(bus_stop, update_data)
-        have_updates = session.is_modified(bus_stop)
-        if have_updates:
-            session.commit()
-            session.refresh(bus_stop)
-
-        bus_stop_data = jsonable_encoder(bus_stop, exclude={BusStop.location.name})
-        bus_stop_data[BusStop.location.name] = (
-            wkb.loads(bytes(bus_stop.location.data))
-        ).wkt
-        if have_updates:
+        updated, bus_stop_data = update_bus_stop(session, id, form_param)
+        if updated:
             log_event(token, request_info, bus_stop_data)
         return bus_stop_data
     except Exception as e:
@@ -443,14 +499,8 @@ async def delete_bus_stop_for_executive(
             [PermissionPath.DELETE_BUS_STOP],
         )
 
-        bus_stop = session.query(BusStop).filter(BusStop.id == id).first()
-        if bus_stop is not None:
-            bus_stop_data = jsonable_encoder(bus_stop, exclude={BusStop.location.name})
-            bus_stop_data[BusStop.location.name] = wkb.loads(
-                bytes(bus_stop.location.data)
-            ).wkt
-            session.delete(bus_stop)
-            session.commit()
+        deleted, bus_stop_data = delete_bus_stop(session, id)
+        if deleted:
             log_event(token, request_info, bus_stop_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
@@ -475,7 +525,10 @@ async def fetch_bus_stops_for_executive(
         session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
 
-        return search_bus_stops(session, query_params)
+        return [
+            bus_stop_to_dict(bus_stop)
+            for bus_stop in search_bus_stops(session, query_params)
+        ]
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -501,7 +554,10 @@ async def fetch_bus_stops_for_vendor(
         session = SessionLocal()
         verify_token(session, VendorToken, access_token.credentials)
 
-        return search_bus_stops(session, query_params)
+        return [
+            bus_stop_to_dict(bus_stop)
+            for bus_stop in search_bus_stops(session, query_params)
+        ]
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -527,7 +583,10 @@ async def fetch_bus_stops_for_operator(
         session = SessionLocal()
         verify_token(session, OperatorToken, access_token.credentials)
 
-        return search_bus_stops(session, query_params)
+        return [
+            bus_stop_to_dict(bus_stop)
+            for bus_stop in search_bus_stops(session, query_params)
+        ]
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -551,7 +610,10 @@ async def fetch_bus_stops_for_public(query_params: QueryParams = Depends()):
     try:
         session = SessionLocal()
 
-        return search_bus_stops(session, query_params)
+        return [
+            bus_stop_to_dict(bus_stop)
+            for bus_stop in search_bus_stops(session, query_params)
+        ]
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/business.py
+++ b/app/api/business.py
@@ -425,10 +425,10 @@ def delete_business(session: Session, id: int) -> tuple[bool, dict]:
         business_data = business_to_dict(business)
         session.delete(business)
         session.commit()
+
         # Delete vendor images from object storage
         for vendor_image in vendor_images:
             delete_file(VENDOR_IMAGES, str(vendor_image.id))
-
         return True, business_data
     return False, {}
 

--- a/app/api/business.py
+++ b/app/api/business.py
@@ -203,7 +203,7 @@ class QueryParams(QueryParamsForEX):
 
 
 # ---------------------------------------------------------------------------
-## Functions
+## Helper Functions
 # ---------------------------------------------------------------------------
 def validate_location(location_wkt: str) -> Point:
     """
@@ -220,9 +220,68 @@ def validate_location(location_wkt: str) -> Point:
     return location_geom
 
 
+def business_to_dict(business: Business) -> dict:
+    """
+    Convert a Business SQLAlchemy model instance to a dictionary with WKT location in WKT format.
+
+    Args:
+        business (Business): Business model instance.
+
+    Returns:
+        dict: Dictionary representation of the business with business location in WKT format.
+    """
+    business_data = jsonable_encoder(
+        business,
+        exclude={Business.location.name},
+    )
+    business_data[Business.location.name] = (
+        wkb.loads(bytes(business.location.data))
+    ).wkt
+    return business_data
+
+
+# ---------------------------------------------------------------------------
+## Core Functions
+# ---------------------------------------------------------------------------
+def create_business(session: Session, form_param: CreateForm) -> dict:
+    """
+    Creates a new Business with the provided form data.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        form_param (CreateForm): Form data for creating a new business.
+
+    Returns:
+        dict: Created business data with location in WKT format.
+    """
+    # Validate location (WKT and SRID)
+    location_geom = validate_location(form_param.location)
+    location = wkt.dumps(location_geom)
+
+    business = Business(
+        name=form_param.name,
+        status=form_param.status,
+        type=form_param.type,
+        description=form_param.description,
+        address=form_param.address,
+        location=location,
+    )
+    session.add(business)
+    # Create Wallet
+    wallet = Wallet(name=form_param.name, balance=0)
+    session.add(wallet)
+    session.flush()
+    # Link Business to Wallet
+    business_wallet = BusinessWallet(business_id=business.id, wallet_id=wallet.id)
+    session.add(business_wallet)
+    session.commit()
+    session.refresh(business)
+    return business_to_dict(business)
+
+
 def update_business(
-    session: Session, id: int, form_param: UpdateForm, extra_filter_for_business=None
-) -> Tuple[bool, dict]:
+    session: Session, id: int, form_param: UpdateForm, business_id: int | None = None
+) -> tuple[bool, dict]:
     """
     Updates a Business with the provided form data.
 
@@ -230,7 +289,6 @@ def update_business(
         session (Session): SQLAlchemy database session.
         id (int): ID of the business to update.
         form_param (UpdateForm): Form data containing fields to update.
-        extra_filter_for_business (optional): Additional filter to apply when fetching the business for update.
 
     Returns:
         Tuple[bool, dict]:
@@ -238,20 +296,21 @@ def update_business(
             - dict: JSON-encoded representation of the updated business.
     """
     business = validate_id(
-        session, Business, id, Business.id, extra_filter=extra_filter_for_business
+        session,
+        Business,
+        id,
+        Business.id,
+        extra_filter=(Business.id == business_id) if business_id else None,
     )
+
     update_data = form_param.model_dump(exclude_unset=True)
-    # Validate location if changed
-    if form_param.location is not None:
-        new_geom = validate_location(form_param.location)
-        old_geom = wkb.loads(bytes(business.location.data))
-
-        if new_geom.wkt != old_geom.wkt:
-            business.location = wkt.dumps(new_geom)
+    if "location" in update_data:
+        old_location_geom = wkb.loads(bytes(business.location.data))
+        new_location_geom = validate_location(form_param.location)
+        if new_location_geom.wkt != old_location_geom.wkt:
+            business.location = wkt.dumps(new_location_geom)
         update_data.pop("location")
-
-    wallet = None
-    if form_param.name is not None:
+    if "name" in update_data:
         if form_param.name != business.name:
             business.name = form_param.name
             business_wallet = (
@@ -274,18 +333,10 @@ def update_business(
     if have_updates:
         session.commit()
         session.refresh(business)
-
-    business_data = jsonable_encoder(
-        business,
-        exclude={Business.location.name},
-    )
-    business_data[Business.location.name] = (
-        wkb.loads(bytes(business.location.data))
-    ).wkt
-    return have_updates, business_data
+    return have_updates, business_to_dict(business)
 
 
-def search_business(session: Session, query_params: QueryParams) -> List[Business]:
+def search_businesses(session: Session, query_params: QueryParams) -> List[Business]:
     """
     Search for businesses based on provided query parameters.
 
@@ -350,17 +401,37 @@ def search_business(session: Session, query_params: QueryParams) -> List[Busines
     query = query.order_by(ordering_func())
     query = query.offset(query_params.offset).limit(query_params.limit)
 
-    query = query.with_entities(
-        Business,
-        func.ST_AsText(Business.location).label("location_wkt"),
-    )
-    results = query.all()
-    businesses = []
-    for business_obj, location_wkt in results:
-        business_obj.location = location_wkt
-        businesses.append(business_obj)
-
+    businesses = query.all()
     return businesses
+
+
+def delete_business(session: Session, id: int) -> tuple[bool, dict]:
+    """
+    Delete a business from the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        id (int): ID of the business to delete.
+
+    Returns:
+        Tuple[bool, dict]:
+            - bool: True if the business was found and deleted, False otherwise.
+            - dict: JSON-encoded representation of the deleted business, or an empty dictionary if not found.
+    """
+    business = session.query(Business).filter(Business.id == id).first()
+    if business is not None:
+        vendor_images = (
+            session.query(VendorImage).filter(VendorImage.business_id == id).all()
+        )
+        business_data = business_to_dict(business)
+        session.delete(business)
+        session.commit()
+        # Delete vendor images from object storage
+        for vendor_image in vendor_images:
+            delete_file(VENDOR_IMAGES, str(vendor_image.id))
+
+        return True, business_data
+    return False, {}
 
 
 # ---------------------------------------------------------------------------
@@ -461,35 +532,7 @@ async def create_business_for_executive(
             [ExecutivePermissionPath.CREATE_BUSINESS],
         )
 
-        # Validate location (WKT and SRID)
-        location_geom = validate_location(form_param.location)
-        validated_location = wkt.dumps(location_geom)
-
-        business = Business(
-            name=form_param.name,
-            status=form_param.status,
-            type=form_param.type,
-            description=form_param.description,
-            address=form_param.address,
-            location=validated_location,
-        )
-        session.add(business)
-
-        # Create Wallet
-        wallet = Wallet(name=form_param.name, balance=0)
-        session.add(wallet)
-        session.flush()
-
-        # Link Business to Wallet
-        business_wallet = BusinessWallet(business_id=business.id, wallet_id=wallet.id)
-        session.add(business_wallet)
-        session.commit()
-        session.refresh(business)
-
-        business_data = jsonable_encoder(business, exclude={Business.location.name})
-        business_data[Business.location.name] = (
-            wkb.loads(bytes(business.location.data))
-        ).wkt
+        business_data = create_business(session, form_param)
         log_event(token, request_info, business_data)
         return business_data
     except Exception as e:
@@ -529,7 +572,6 @@ async def update_business_for_executive(
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
         )
-
         if have_updates:
             log_event(token, request_info, business_data)
         return business_data
@@ -555,10 +597,10 @@ async def fetch_businesses_for_executive(
         session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
 
-        return search_business(
-            session,
-            QueryParams(**query_params.model_dump()),
-        )
+        return [
+            business_to_dict(business)
+            for business in search_businesses(session, query_params)
+        ]
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -590,25 +632,8 @@ async def delete_business_for_executive(
             [ExecutivePermissionPath.DELETE_BUSINESS],
         )
 
-        business = session.query(Business).filter(Business.id == id).first()
-        if business is not None:
-            vendor_images = (
-                session.query(VendorImage).filter(VendorImage.business_id == id).all()
-            )
-            business_data = jsonable_encoder(
-                business,
-                exclude={Business.location.name},
-            )
-            business_data[Business.location.name] = (
-                wkb.loads(bytes(business.location.data))
-            ).wkt
-            session.delete(business)
-            session.commit()
-
-            # Delete vendor images from object storage
-            for vendor_image in vendor_images:
-                delete_file(VENDOR_IMAGES, str(vendor_image.id))
-
+        deleted, business_data = delete_business(session, id)
+        if deleted:
             log_event(token, request_info, business_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
@@ -650,9 +675,8 @@ async def update_business_for_vendor(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
-            extra_filter_for_business=(Business.id == token.business_id),
+            token.business_id,
         )
-
         if have_updates:
             log_event(token, request_info, business_data)
         return business_data
@@ -676,9 +700,12 @@ async def fetch_businesses_for_vendor(access_token=Depends(bearer_vendor)):
         token = verify_token(session, VendorToken, access_token.credentials)
 
         query_params = resolve_model_defaults(
-            QueryParams, id_list=[token.business_id], offset=0, limit=1
+            QueryParams, id=token.business_id, offset=0, limit=1
         )
-        return search_business(session, query_params)
+        return [
+            business_to_dict(business)
+            for business in search_businesses(session, query_params)
+        ]
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -709,15 +736,10 @@ async def fetch_businesses_for_public(
     try:
         session = SessionLocal()
 
-        return search_business(
-            session,
-            QueryParams(
-                **query_params.model_dump(),
-                status_list=[BusinessStatus.ACTIVE],
-                address=None,
-                description=None,
-            ),
+        query_params = QueryParams(
+            **query_params.model_dump(), status_list=[BusinessStatus.ACTIVE]
         )
+        return search_businesses(session, query_params)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/business.py
+++ b/app/api/business.py
@@ -289,6 +289,7 @@ def update_business(
         session (Session): SQLAlchemy database session.
         id (int): ID of the business to update.
         form_param (UpdateForm): Form data containing fields to update.
+        business_id (int | None): Optional business ID for additional filtering.
 
     Returns:
         Tuple[bool, dict]:

--- a/app/api/business.py
+++ b/app/api/business.py
@@ -304,6 +304,7 @@ def update_business(
     )
 
     update_data = form_param.model_dump(exclude_unset=True)
+    wallet = None
     if "location" in update_data:
         old_location_geom = wkb.loads(bytes(business.location.data))
         new_location_geom = validate_location(form_param.location)
@@ -327,13 +328,11 @@ def update_business(
         update_data.pop("name")
 
     update_if_changed(business, update_data)
-    have_updates = session.is_modified(business) or (
-        wallet and session.is_modified(wallet)
-    )
-    if have_updates:
+    updated = session.is_modified(business) or (wallet and session.is_modified(wallet))
+    if updated:
         session.commit()
         session.refresh(business)
-    return have_updates, business_to_dict(business)
+    return updated, business_to_dict(business)
 
 
 def search_businesses(session: Session, query_params: QueryParams) -> List[Business]:
@@ -567,12 +566,12 @@ async def update_business_for_executive(
             [ExecutivePermissionPath.UPDATE_BUSINESS],
         )
 
-        have_updates, business_data = update_business(
+        updated, business_data = update_business(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
         )
-        if have_updates:
+        if updated:
             log_event(token, request_info, business_data)
         return business_data
     except Exception as e:
@@ -671,13 +670,13 @@ async def update_business_for_vendor(
             [VendorPermissionPath.UPDATE_BUSINESS],
         )
 
-        have_updates, business_data = update_business(
+        updated, business_data = update_business(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
             token.business_id,
         )
-        if have_updates:
+        if updated:
             log_event(token, request_info, business_data)
         return business_data
     except Exception as e:

--- a/app/api/business.py
+++ b/app/api/business.py
@@ -733,9 +733,13 @@ async def fetch_businesses_for_public(
         session = SessionLocal()
 
         query_params = QueryParams(
-            **query_params.model_dump(), status_list=[BusinessStatus.ACTIVE]
+            **query_params.model_dump(),
+            status_list=[BusinessStatus.ACTIVE],
+            address=None,
+            description=None,
         )
-        return search_businesses(session, query_params)
+        businesses = search_businesses(session, query_params)
+        return businesses
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/business.py
+++ b/app/api/business.py
@@ -8,7 +8,7 @@ input validation and structured output.
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Tuple, List
+from typing import List
 from fastapi import APIRouter, Query, Response, status, Depends
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field

--- a/app/api/business.py
+++ b/app/api/business.py
@@ -280,7 +280,7 @@ def create_business(session: Session, form_param: CreateForm) -> dict:
 
 
 def update_business(
-    session: Session, id: int, form_param: UpdateForm, business_id: int | None = None
+    session: Session, id: int, form_param: UpdateForm, business_filter=None
 ) -> tuple[bool, dict]:
     """
     Updates a Business with the provided form data.
@@ -289,7 +289,7 @@ def update_business(
         session (Session): SQLAlchemy database session.
         id (int): ID of the business to update.
         form_param (UpdateForm): Form data containing fields to update.
-        business_id (int | None): Optional business ID for additional filtering.
+        business_filter (Optional): Additional filter for business validation.
 
     Returns:
         Tuple[bool, dict]:
@@ -297,11 +297,7 @@ def update_business(
             - dict: JSON-encoded representation of the updated business.
     """
     business = validate_id(
-        session,
-        Business,
-        id,
-        Business.id,
-        extra_filter=(Business.id == business_id) if business_id else None,
+        session, Business, id, Business.id, extra_filter=business_filter
     )
 
     update_data = form_param.model_dump(exclude_unset=True)
@@ -675,7 +671,7 @@ async def update_business_for_vendor(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
-            token.business_id,
+            business_filter=(Business.id == token.business_id),
         )
         if updated:
             log_event(token, request_info, business_data)

--- a/app/api/company.py
+++ b/app/api/company.py
@@ -734,7 +734,10 @@ async def fetch_companies_for_public(
         session = SessionLocal()
 
         query_params = QueryParams(
-            **query_params.model_dump(), status_list=[CompanyStatus.VERIFIED]
+            **query_params.model_dump(),
+            status_list=[CompanyStatus.VERIFIED],
+            address=None,
+            description=None,
         )
         return search_companies(session, query_params)
     except Exception as e:

--- a/app/api/company.py
+++ b/app/api/company.py
@@ -19,12 +19,13 @@ from sqlalchemy import func, String, or_
 from geoalchemy2 import Geography
 
 from app.api.bearer import oauth2_executive, bearer_operator
-from app.src.buckets import OPERATOR_IMAGES
+from app.src.buckets import OPERATOR_IMAGES, VEHICLE_IMAGES
 from app.src.db import (
     Company,
     ExecutiveToken,
     OperatorToken,
     SessionLocal,
+    VehicleImage,
     Wallet,
     CompanyWallet,
     OperatorImage,
@@ -203,7 +204,7 @@ class QueryParams(QueryParamsForEX):
 
 
 # ---------------------------------------------------------------------------
-## Functions
+## Helper Functions
 # ---------------------------------------------------------------------------
 def validate_location(location_wkt: str) -> Point:
     """
@@ -218,13 +219,69 @@ def validate_location(location_wkt: str) -> Point:
     # Validate WKT and SRID
     location_geom = validate_wkt_string(location_wkt, Point)
     validate_srid_4326(location_geom)
-
     return location_geom
 
 
+def company_to_dict(company: Company) -> dict:
+    """
+    Convert a Company SQLAlchemy model instance to a dictionary with WKT location in WKT format.
+
+    Args:
+        company (Company): Company model instance.
+
+    Returns:
+        dict: Dictionary representation of the company with company location in WKT format.
+    """
+    company_data = jsonable_encoder(
+        company,
+        exclude={Company.location.name},
+    )
+    company_data[Company.location.name] = (wkb.loads(bytes(company.location.data))).wkt
+    return company_data
+
+
+# ---------------------------------------------------------------------------
+## Core Functions
+# ---------------------------------------------------------------------------
+def create_company(session: Session, form_param: CreateForm) -> dict:
+    """
+    Creates a new Company with the provided form data.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        form_param (CreateForm): Form data for creating a new company.
+
+    Returns:
+        dict: Created company data with location in WKT format.
+    """
+    # Validate location (WKT and SRID)
+    location_geom = validate_location(form_param.location)
+    location = wkt.dumps(location_geom)
+
+    company = Company(
+        name=form_param.name,
+        status=form_param.status,
+        type=form_param.type,
+        description=form_param.description,
+        address=form_param.address,
+        location=location,
+    )
+    session.add(company)
+    # Create Wallet
+    wallet = Wallet(name=form_param.name, balance=0)
+    session.add(wallet)
+    session.flush()
+    # Link Company to Wallet
+    company_wallet = CompanyWallet(company_id=company.id, wallet_id=wallet.id)
+    session.add(company_wallet)
+    session.commit()
+    session.refresh(company)
+    return company_to_dict(company)
+
+
 def update_company(
-    session: Session, id: int, form_param: UpdateForm, extra_filter_for_company=None
-) -> Tuple[bool, dict]:
+    session: Session, id: int, form_param: UpdateForm, company_id: int | None = None
+) -> tuple[bool, dict]:
     """
     Updates a Company with the provided form data.
 
@@ -232,28 +289,29 @@ def update_company(
         session (Session): SQLAlchemy database session.
         id (int): ID of the company to update.
         form_param (UpdateForm): Form data containing fields to update.
-        extra_filter_for_company (optional): Additional filter to apply when validating the company ID.
 
     Returns:
-    Tuple[bool, dict]:
+        Tuple[bool, dict]:
             - bool: True if the company was modified and the changes were committed.
             - dict: JSON-encoded representation of the updated company.
     """
     company = validate_id(
-        session, Company, id, Company.id, extra_filter=extra_filter_for_company
+        session,
+        Company,
+        id,
+        Company.id,
+        extra_filter=(Company.id == company_id) if company_id else None,
     )
+
     update_data = form_param.model_dump(exclude_unset=True)
-    # Validate location if changed
-    if form_param.location is not None:
-        new_geom = validate_location(form_param.location)
-        old_geom = wkb.loads(bytes(company.location.data))
-
-        if new_geom.wkt != old_geom.wkt:
-            company.location = wkt.dumps(new_geom)
-        update_data.pop("location")
-
     wallet = None
-    if form_param.name is not None:
+    if "location" in update_data:
+        old_location_geom = wkb.loads(bytes(company.location.data))
+        new_location_geom = validate_location(form_param.location)
+        if new_location_geom.wkt != old_location_geom.wkt:
+            company.location = wkt.dumps(new_location_geom)
+        update_data.pop("location")
+    if "name" in update_data:
         if form_param.name != company.name:
             company.name = form_param.name
             company_wallet = (
@@ -270,22 +328,13 @@ def update_company(
         update_data.pop("name")
 
     update_if_changed(company, update_data)
-    have_updates = session.is_modified(company) or (
-        wallet and session.is_modified(wallet)
-    )
-    if have_updates:
+    updated = session.is_modified(company) or (wallet and session.is_modified(wallet))
+    if updated:
         session.commit()
         session.refresh(company)
 
-    company_data = jsonable_encoder(
-        company,
-        exclude={Company.location.name},
-    )
-    company_data[Company.location.name] = (wkb.loads(bytes(company.location.data))).wkt
-    return have_updates, company_data
 
-
-def search_company(session: Session, query_params: QueryParams) -> List[Company]:
+def search_companies(session: Session, query_params: QueryParams) -> List[Company]:
     """
     Search for companies based on provided query parameters.
 
@@ -348,17 +397,43 @@ def search_company(session: Session, query_params: QueryParams) -> List[Company]
     query = query.order_by(ordering_func())
     query = query.offset(query_params.offset).limit(query_params.limit)
 
-    query = query.with_entities(
-        Company,
-        func.ST_AsText(Company.location).label("location_wkt"),
-    )
-    results = query.all()
-    companies = []
-    for company_obj, location_wkt in results:
-        company_obj.location = location_wkt
-        companies.append(company_obj)
-
+    companies = query.all()
     return companies
+
+
+def delete_company(session: Session, id: int) -> tuple[bool, dict]:
+    """
+    Delete a company from the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        id (int): ID of the company to delete.
+
+    Returns:
+        Tuple[bool, dict]:
+            - bool: True if the company was found and deleted, False otherwise.
+            - dict: JSON-encoded representation of the deleted company, or an empty dictionary if not found.
+    """
+    company = session.query(Company).filter(Company.id == id).first()
+    if company is not None:
+        operator_images = (
+            session.query(OperatorImage).filter(OperatorImage.company_id == id).all()
+        )
+        vehicle_images = (
+            session.query(VehicleImage).filter(VehicleImage.company_id == id).all()
+        )
+        company_data = company_to_dict(company)
+        session.delete(company)
+        session.commit()
+
+        # Delete operator images from object storage
+        for operator_image in operator_images:
+            delete_file(OPERATOR_IMAGES, str(operator_image.id))
+        # Delete vehicle images from object storage
+        for vehicle_image in vehicle_images:
+            delete_file(VEHICLE_IMAGES, str(vehicle_image.id))
+        return True, company_data
+    return False, {}
 
 
 # ---------------------------------------------------------------------------
@@ -460,35 +535,7 @@ async def create_company_for_executive(
             [ExecutivePermissionPath.CREATE_COMPANY],
         )
 
-        # Validate location (WKT and SRID)
-        location_geom = validate_location(form_param.location)
-        validated_location = wkt.dumps(location_geom)
-
-        company = Company(
-            name=form_param.name,
-            status=form_param.status,
-            type=form_param.type,
-            description=form_param.description,
-            address=form_param.address,
-            location=validated_location,
-        )
-        session.add(company)
-
-        # Create Wallet
-        wallet = Wallet(name=form_param.name, balance=0)
-        session.add(wallet)
-        session.flush()
-
-        # Link Company to Wallet
-        company_wallet = CompanyWallet(company_id=company.id, wallet_id=wallet.id)
-        session.add(company_wallet)
-        session.commit()
-        session.refresh(company)
-
-        company_data = jsonable_encoder(company, exclude={Company.location.name})
-        company_data[Company.location.name] = (
-            wkb.loads(bytes(company.location.data))
-        ).wkt
+        company_data = create_company(session, form_param)
         log_event(token, request_info, company_data)
         return company_data
     except Exception as e:
@@ -523,10 +570,10 @@ async def update_company_for_executive(
             [ExecutivePermissionPath.UPDATE_COMPANY],
         )
 
-        have_updates, company_data = update_company(
+        updated, company_data = update_company(
             session, id, UpdateForm(**form_param.model_dump(exclude_unset=True))
         )
-        if have_updates:
+        if updated:
             log_event(token, request_info, company_data)
         return company_data
     except Exception as e:
@@ -551,10 +598,10 @@ async def fetch_companies_for_executive(
         session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
 
-        return search_company(
-            session,
-            QueryParams(**query_params.model_dump()),
-        )
+        return [
+            company_to_dict(company)
+            for company in search_companies(session, query_params)
+        ]
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -586,27 +633,8 @@ async def delete_company_for_executive(
             [ExecutivePermissionPath.DELETE_COMPANY],
         )
 
-        company = session.query(Company).filter(Company.id == id).first()
-        if company is not None:
-            operator_images = (
-                session.query(OperatorImage)
-                .filter(OperatorImage.company_id == id)
-                .all()
-            )
-            company_data = jsonable_encoder(
-                company,
-                exclude={Company.location.name},
-            )
-            company_data[Company.location.name] = (
-                wkb.loads(bytes(company.location.data))
-            ).wkt
-            session.delete(company)
-            session.commit()
-
-            # Delete operator images
-            for operator_image in operator_images:
-                delete_file(OPERATOR_IMAGES, str(operator_image.id))
-
+        deleted, company_data = delete_company(session, id)
+        if deleted:
             log_event(token, request_info, company_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
@@ -644,13 +672,13 @@ async def update_company_for_operator(
             [OperatorPermissionPath.UPDATE_COMPANY],
         )
 
-        have_updates, company_data = update_company(
+        updated, company_data = update_company(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
-            extra_filter_for_company=(Company.id == token.company_id),
+            token.company_id,
         )
-        if have_updates:
+        if updated:
             log_event(token, request_info, company_data)
         return company_data
     except Exception as e:
@@ -673,9 +701,12 @@ async def fetch_companies_for_operator(access_token=Depends(bearer_operator)):
         token = verify_token(session, OperatorToken, access_token.credentials)
 
         query_params = resolve_model_defaults(
-            QueryParams, id_list=[token.company_id], offset=0, limit=1
+            QueryParams, id=token.company_id, offset=0, limit=1
         )
-        return search_company(session, query_params)
+        return [
+            company_to_dict(company)
+            for company in search_companies(session, query_params)
+        ]
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -706,15 +737,10 @@ async def fetch_companies_for_public(
     try:
         session = SessionLocal()
 
-        return search_company(
-            session,
-            QueryParams(
-                **query_params.model_dump(),
-                status_list=[CompanyStatus.VERIFIED],
-                address=None,
-                description=None,
-            ),
+        query_params = QueryParams(
+            **query_params.model_dump(), status_list=[CompanyStatus.VERIFIED]
         )
+        return search_companies(session, query_params)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/company.py
+++ b/app/api/company.py
@@ -332,6 +332,7 @@ def update_company(
     if updated:
         session.commit()
         session.refresh(company)
+    return updated, company_to_dict(company)
 
 
 def search_companies(session: Session, query_params: QueryParams) -> List[Company]:

--- a/app/api/company.py
+++ b/app/api/company.py
@@ -289,6 +289,7 @@ def update_company(
         session (Session): SQLAlchemy database session.
         id (int): ID of the company to update.
         form_param (UpdateForm): Form data containing fields to update.
+        company_id (int | None): Optional company ID for additional filtering.
 
     Returns:
         Tuple[bool, dict]:

--- a/app/api/company.py
+++ b/app/api/company.py
@@ -8,7 +8,7 @@ input validation and structured output.
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Tuple, List
+from typing import List
 from fastapi import APIRouter, Query, Response, status, Depends
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field

--- a/app/api/company.py
+++ b/app/api/company.py
@@ -280,7 +280,7 @@ def create_company(session: Session, form_param: CreateForm) -> dict:
 
 
 def update_company(
-    session: Session, id: int, form_param: UpdateForm, company_id: int | None = None
+    session: Session, id: int, form_param: UpdateForm, company_filter=None
 ) -> tuple[bool, dict]:
     """
     Updates a Company with the provided form data.
@@ -289,20 +289,14 @@ def update_company(
         session (Session): SQLAlchemy database session.
         id (int): ID of the company to update.
         form_param (UpdateForm): Form data containing fields to update.
-        company_id (int | None): Optional company ID for additional filtering.
+        company_filter (Optional): Additional filter for company validation.
 
     Returns:
         Tuple[bool, dict]:
             - bool: True if the company was modified and the changes were committed.
             - dict: JSON-encoded representation of the updated company.
     """
-    company = validate_id(
-        session,
-        Company,
-        id,
-        Company.id,
-        extra_filter=(Company.id == company_id) if company_id else None,
-    )
+    company = validate_id(session, Company, id, Company.id, extra_filter=company_filter)
 
     update_data = form_param.model_dump(exclude_unset=True)
     wallet = None
@@ -678,7 +672,7 @@ async def update_company_for_operator(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
-            token.company_id,
+            company_filter=(Company.id == token.company_id),
         )
         if updated:
             log_event(token, request_info, company_data)

--- a/app/api/duty.py
+++ b/app/api/duty.py
@@ -121,10 +121,10 @@ class QueryParams(QueryParamsForEX):
 
 
 # ---------------------------------------------------------------------------
-## Functions
+## Core Functions
 # ---------------------------------------------------------------------------
 def update_duty(
-    session: Session, id: int, form_param: UpdateForm, extra_filter_for_duty=None
+    session: Session, id: int, form_param: UpdateForm, company_id: int | None = None
 ) -> tuple[bool, dict]:
     """
     Updates a duty record based on the requested status transition.
@@ -137,15 +137,21 @@ def update_duty(
         session (Session): SQLAlchemy database session.
         id (int): ID of the duty to update.
         form_param (UpdateForm): Form data containing new status.
-        extra_filter_for_duty (optional): Additional filter to apply when validating the duty ID.
+        company_id (int | None): ID of the company associated with the duty.
 
     Returns:
-        tuple[bool, dict]: (have_updates, duty_data)
+        Tuple[bool, dict]:
+            - bool: True if the duty was modified and the changes were committed.
+            - dict: JSON-encoded representation of the updated duty.
     """
     service_lock = None
     try:
         duty = validate_id(
-            session, Duty, id, Duty.id, extra_filter=extra_filter_for_duty
+            session,
+            Duty,
+            id,
+            Duty.id,
+            extra_filter=(Duty.company_id == company_id) if company_id else None,
         )
         service_lock = acquire_lock(construct_service_transition_lock(duty.service_id))
         session.refresh(duty)
@@ -157,46 +163,49 @@ def update_duty(
 
         update_data = form_param.model_dump(exclude_unset=True)
         service = None
-        if "status" in update_data and update_data["status"] != duty.status:
-            new_status = update_data["status"]
-            validate_state_transition(
-                allowed_duty_status_transitions,
-                duty.status,
-                new_status,
-                Duty.status,
-            )
-            if new_status == DutyStatus.ENDED:
-                duty.collection = (
-                    session.query(func.sum(PaperTicket.amount))
-                    .filter(PaperTicket.duty_id == duty.id)
-                    .scalar()
+        if "status" in update_data:
+            if form_param.status != duty.status:
+                validate_state_transition(
+                    allowed_duty_status_transitions,
+                    duty.status,
+                    form_param.status,
+                    Duty.status,
                 )
-                utc_now = datetime.now(timezone.utc)
-                duty.finished_on = utc_now
-            elif new_status == DutyStatus.STARTED:
-                duty.finished_on = None
-                duty.collection = 0
-                service = (
-                    session.query(Service).filter(Service.id == duty.service_id).first()
-                )
-                if service.status == ServiceStatus.ENDED:
-                    service.status = ServiceStatus.STARTED
-            duty.status = new_status
+                # Handle status transitions
+                if form_param.status == DutyStatus.ENDED:
+                    duty.collection = (
+                        session.query(func.sum(PaperTicket.amount))
+                        .filter(PaperTicket.duty_id == duty.id)
+                        .scalar()
+                    )
+                    utc_now = datetime.now(timezone.utc)
+                    duty.finished_on = utc_now
+                elif form_param.status == DutyStatus.STARTED:
+                    duty.finished_on = None
+                    duty.collection = 0
+                    service = (
+                        session.query(Service)
+                        .filter(Service.id == duty.service_id)
+                        .first()
+                    )
+                    if service.status == ServiceStatus.ENDED:
+                        service.status = ServiceStatus.STARTED
+                duty.status = form_param.status
+                update_data.pop("status")
 
-        have_updates = session.is_modified(duty) or (
-            service is not None and session.is_modified(service)
+        updated = session.is_modified(duty) or (
+            service and session.is_modified(service)
         )
-        if have_updates:
+        if updated:
             session.commit()
             session.refresh(duty)
-
         duty_data = jsonable_encoder(duty)
-        return have_updates, duty_data
+        return updated, duty_data
     finally:
         release_lock(service_lock)
 
 
-def search_duty(session: Session, query_params: QueryParams) -> List[Duty]:
+def search_duties(session: Session, query_params: QueryParams) -> List[Duty]:
     """
     Search for Duties based on provided query parameters.
 
@@ -304,10 +313,10 @@ async def update_duty_for_executive(
             [ExecutivePermissionPath.UPDATE_COMPANY_SERVICE_DUTY],
         )
 
-        have_updates, duty_data = update_duty(
+        updated, duty_data = update_duty(
             session, id, UpdateForm(**form_param.model_dump(exclude_unset=True))
         )
-        if have_updates:
+        if updated:
             log_event(token, request_info, duty_data)
         return duty_data
     except Exception as e:
@@ -332,7 +341,7 @@ async def fetch_duties_for_executive(
         session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
 
-        return search_duty(session, QueryParams(**query_params.model_dump()))
+        return search_duties(session, QueryParams(**query_params.model_dump()))
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -371,13 +380,13 @@ async def update_duty_for_operator(
             [OperatorPermissionPath.UPDATE_COMPANY_SERVICE_DUTY],
         )
 
-        have_updates, duty_data = update_duty(
+        updated, duty_data = update_duty(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
-            extra_filter_for_duty=(Duty.company_id == token.company_id),
+            token.company_id,
         )
-        if have_updates:
+        if updated:
             log_event(token, request_info, duty_data)
         return duty_data
     except Exception as e:
@@ -402,13 +411,10 @@ async def fetch_duties_for_operator(
         session = SessionLocal()
         token = verify_token(session, OperatorToken, access_token.credentials)
 
-        return search_duty(
-            session,
-            QueryParams(
-                **query_params.model_dump(),
-                company_id=token.company_id,
-            ),
+        query_params = QueryParams(
+            **query_params.model_dump(), company_id=token.company_id
         )
+        return search_duties(session, query_params)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/executive_account.py
+++ b/app/api/executive_account.py
@@ -14,6 +14,7 @@ from fastapi.encoders import jsonable_encoder
 from pydantic_extra_types.phone_numbers import PhoneNumber
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import String, or_
+from sqlalchemy.orm.session import Session
 
 from app.api.bearer import oauth2_executive
 from app.src.buckets import EXECUTIVE_IMAGES
@@ -144,6 +145,155 @@ class QueryParams(
 
 
 # ---------------------------------------------------------------------------
+## Core Functions
+# ---------------------------------------------------------------------------
+def create_executive(session: Session, form_param: CreateForm) -> dict:
+    """
+    Creates a new executive account with the provided form data.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        form_param (CreateForm): Form data for creating a new executive account.
+
+    Returns:
+        dict: Created executive account data.
+    """
+    executive = Executive(
+        username=form_param.username,
+        password=form_param.password,
+        gender=form_param.gender,
+        full_name=form_param.full_name,
+        designation=form_param.designation,
+        phone_number=form_param.phone_number,
+        email_id=form_param.email_id,
+    )
+    session.add(executive)
+    session.commit()
+    session.refresh(executive)
+    return jsonable_encoder(executive, exclude={Executive.password.name})
+
+
+def update_executive(
+    session: Session, id: int, form_param: UpdateForm
+) -> tuple[bool, dict]:
+    """
+    Updates an Executive account with the provided form data.
+
+    Args:
+        session (Session): SQLAlchemy database session.
+        id (int): ID of the executive account to update.
+        form_param (UpdateForm): Form data containing fields to update.
+
+    Returns:
+        Tuple[bool, dict]:
+            - bool: True if the executive account was modified and the changes were committed.
+            - dict: JSON-encoded representation of the updated executive account.
+    """
+    executive = validate_id(session, Executive, id, Executive.id)
+
+    update_data = form_param.model_dump(exclude_unset=True)
+    update_if_changed(executive, update_data)
+    if "status" in update_data:
+        if form_param.status == AccountStatus.SUSPENDED:
+            session.query(ExecutiveToken).filter(
+                ExecutiveToken.executive_id == id,
+                ExecutiveToken.is_revoked.is_(False),
+            ).update({ExecutiveToken.is_revoked: True})
+        executive.status = form_param.status
+        update_data.pop("status")
+
+    update_if_changed(executive, update_data)
+    updated = session.is_modified(executive)
+    if updated:
+        session.commit()
+        session.refresh(executive)
+    return updated, jsonable_encoder(executive, exclude={Executive.password.name})
+
+
+def search_executives(session: Session, query_params: QueryParams) -> List[Executive]:
+    """
+    Searches for executive accounts based on the provided query parameters.
+
+    Args:
+        session (Session): SQLAlchemy database session.
+        query_params (QueryParams): Query parameters for filtering and pagination.
+
+    Returns:
+        List[Executive]: List of executive accounts matching the search criteria.
+    """
+    query = session.query(Executive)
+    if query_params.designation is not None:
+        query = query.filter(
+            Executive.designation.ilike(f"%{query_params.designation}%")
+        )
+
+    # Common search
+    if query_params.search:
+        search = f"%{query_params.search}%"
+        query = query.filter(
+            or_(
+                Executive.id.cast(String).ilike(search),
+                Executive.username.ilike(search),
+                Executive.full_name.ilike(search),
+                Executive.designation.ilike(search),
+                Executive.phone_number.ilike(search),
+                Executive.email_id.ilike(search),
+            )
+        )
+
+    # Generalized filters
+    query = apply_id_filters(query, Executive, query_params)
+    query = apply_created_on_filters(query, Executive, query_params)
+    query = apply_updated_on_filters(query, Executive, query_params)
+    query = apply_account_filters(query, Executive, query_params)
+    query = apply_status_filters(query, Executive, query_params)
+
+    # Ordering and pagination
+    ordering_attr = getattr(Executive, query_params.order_by.value)
+    ordering_func = (
+        ordering_attr.asc
+        if query_params.order_in == OrderIn.ASCENDING
+        else ordering_attr.desc
+    )
+    query = query.order_by(ordering_func())
+    query = query.offset(query_params.offset).limit(query_params.limit)
+
+    executives = query.all()
+    return executives
+
+
+def delete_executive(session: Session, id: int) -> tuple[bool, dict]:
+    """
+    Delete an executive account from the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        id (int): ID of the executive account to delete.
+
+    Returns:
+        Tuple[bool, dict]:
+            - bool: True if the executive account was found and deleted, False otherwise.
+            - dict: JSON-encoded representation of the deleted executive account, or an empty dictionary if not found.
+    """
+    executive = session.query(Executive).filter(Executive.id == id).first()
+    if executive is not None:
+        executive_images = (
+            session.query(ExecutiveImage)
+            .filter(ExecutiveImage.executive_id == id)
+            .all()
+        )
+        executive_data = jsonable_encoder(executive, exclude={Executive.password.name})
+        session.delete(executive)
+        session.commit()
+
+        # Delete executive images from object storage
+        for executive_image in executive_images:
+            delete_file(EXECUTIVE_IMAGES, str(executive_image.id))
+        return True, executive_data
+    return False, {}
+
+
+# ---------------------------------------------------------------------------
 ## Common exceptions
 # ---------------------------------------------------------------------------
 POST_EXCEPTIONS = [
@@ -194,6 +344,7 @@ DELETE_DESCRIPTION = (
     .add_line("Self-deletion is not allowed for safety reasons.")
     .add_line("Returns 204 No Content even if the specified account does not exist.")
     .add_line("Logged-in executive must have the `executive.delete` permission.")
+    .add_line("All associated executive images will be deleted upon account deletion.")
 )
 
 GET_DESCRIPTION = Description().add_head("Fetches a list of executives.")
@@ -222,20 +373,7 @@ async def create_executive_account_for_executive(
             session, access_token, [PermissionPath.CREATE_EXECUTIVE]
         )
 
-        executive = Executive(
-            username=form_param.username,
-            password=form_param.password,
-            gender=form_param.gender,
-            full_name=form_param.full_name,
-            designation=form_param.designation,
-            phone_number=form_param.phone_number,
-            email_id=form_param.email_id,
-        )
-        session.add(executive)
-        session.commit()
-        session.refresh(executive)
-
-        executive_data = jsonable_encoder(executive, exclude={Executive.password.name})
+        executive_data = create_executive(session, form_param)
         log_event(token, request_info, executive_data)
         return executive_data
     except Exception as e:
@@ -262,36 +400,15 @@ async def update_executive_account_for_executive(
         session = SessionLocal()
         token = verify_token(session, ExecutiveToken, access_token)
 
-        executive = validate_id(session, Executive, id, Executive.id)
-        update_data = form_param.model_dump(exclude_unset=True)
-        is_self_update = executive.id == token.executive_id
+        is_self_update = id == token.executive_id
         if not is_self_update:
             roles = get_executive_roles(session, token)
             verify_permission(roles, PermissionPath.UPDATE_EXECUTIVE)
-        if is_self_update and Executive.status.key in update_data:
+        if is_self_update and form_param.status is not None:
             raise exceptions.NoPermission()
 
-        # Revoking all the tokens for a suspended executive
-        tokens_revoked = False
-        if form_param.status == AccountStatus.SUSPENDED:
-            tokens_revoked = (
-                session.query(ExecutiveToken)
-                .filter(
-                    ExecutiveToken.executive_id == id,
-                    ExecutiveToken.is_revoked.is_(False),
-                )
-                .update({ExecutiveToken.is_revoked: True})
-                > 0
-            )
-
-        update_if_changed(executive, update_data)
-        have_updates = session.is_modified(executive) or tokens_revoked
-        if have_updates:
-            session.commit()
-            session.refresh(executive)
-
-        executive_data = jsonable_encoder(executive, exclude={Executive.password.name})
-        if have_updates:
+        updated, executive_data = update_executive(session, id, form_param)
+        if updated:
             log_event(token, request_info, executive_data)
         return executive_data
     except Exception as e:
@@ -321,22 +438,9 @@ async def delete_executive_account_for_executive(
 
         if token.executive_id == id:
             raise exceptions.NoPermission()
-        executive = session.query(Executive).filter(Executive.id == id).first()
-        if executive is not None:
-            executive_image = (
-                session.query(ExecutiveImage)
-                .filter(ExecutiveImage.executive_id == id)
-                .first()
-            )
-            executive_data = jsonable_encoder(
-                executive, exclude={Executive.password.name}
-            )
-            session.delete(executive)
-            session.commit()
-            # Delete executive image
-            if executive_image is not None:
-                delete_file(EXECUTIVE_IMAGES, str(executive_image.id))
 
+        deleted, executive_data = delete_executive(session, id)
+        if deleted:
             log_event(token, request_info, executive_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
@@ -361,45 +465,7 @@ async def fetch_executive_accounts_for_executive(
         session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
 
-        query = session.query(Executive)
-        if query_params.designation is not None:
-            query = query.filter(
-                Executive.designation.ilike(f"%{query_params.designation}%")
-            )
-
-        # Common search
-        if query_params.search:
-            search = f"%{query_params.search}%"
-            query = query.filter(
-                or_(
-                    Executive.id.cast(String).ilike(search),
-                    Executive.username.ilike(search),
-                    Executive.full_name.ilike(search),
-                    Executive.designation.ilike(search),
-                    Executive.phone_number.ilike(search),
-                    Executive.email_id.ilike(search),
-                )
-            )
-
-        # Generalized filters
-        query = apply_id_filters(query, Executive, query_params)
-        query = apply_created_on_filters(query, Executive, query_params)
-        query = apply_updated_on_filters(query, Executive, query_params)
-        query = apply_account_filters(query, Executive, query_params)
-        query = apply_status_filters(query, Executive, query_params)
-
-        # Ordering and pagination
-        ordering_attr = getattr(Executive, query_params.order_by.value)
-        ordering_func = (
-            ordering_attr.asc
-            if query_params.order_in == OrderIn.ASCENDING
-            else ordering_attr.desc
-        )
-        query = query.order_by(ordering_func())
-        query = query.offset(query_params.offset).limit(query_params.limit)
-
-        executives = query.all()
-        return executives
+        return search_executives(session, query_params)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/executive_account.py
+++ b/app/api/executive_account.py
@@ -192,7 +192,6 @@ def update_executive(
     executive = validate_id(session, Executive, id, Executive.id)
 
     update_data = form_param.model_dump(exclude_unset=True)
-    update_if_changed(executive, update_data)
     if "status" in update_data:
         if form_param.status == AccountStatus.SUSPENDED:
             session.query(ExecutiveToken).filter(

--- a/app/api/executive_role.py
+++ b/app/api/executive_role.py
@@ -8,10 +8,12 @@ input validation and structured output.
 
 from datetime import datetime
 from enum import StrEnum
+from typing import List
 from fastapi import APIRouter, Query, Response, status, Depends
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from sqlalchemy import or_, String
+from sqlalchemy.orm.session import Session
 
 from app.api.bearer import oauth2_executive
 from app.src.db import ExecutiveRole, ExecutiveToken, SessionLocal
@@ -99,6 +101,129 @@ class QueryParams(
 
 
 # ---------------------------------------------------------------------------
+## Core Functions
+# ---------------------------------------------------------------------------
+def create_executive_role(session: Session, form_param: CreateForm) -> dict:
+    """
+    Creates a new executive role with the provided form data.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        form_param (CreateForm): Form data for creating a new executive role.
+
+    Returns:
+        dict: Created executive role data.
+    """
+    role_count = session.query(ExecutiveRole).count()
+    if role_count >= MAX_EXECUTIVE_ROLE:
+        raise exceptions.LimitExceeded(ExecutiveRole)
+
+    executive_role = ExecutiveRole(
+        name=form_param.name,
+        permissions=form_param.permissions.model_dump(),
+    )
+    session.add(executive_role)
+    session.commit()
+    session.refresh(executive_role)
+    return jsonable_encoder(executive_role)
+
+
+def update_executive_role(
+    session: Session, id: int, form_param: UpdateForm
+) -> tuple[bool, dict]:
+    """
+    Updates an ExecutiveRole with the provided form data.
+
+    Args:
+        session (Session): SQLAlchemy database session.
+        id (int): ID of the executive role to update.
+        form_param (UpdateForm): Form data containing fields to update.
+
+    Returns:
+        Tuple[bool, dict]:
+            - bool: True if the executive role was modified and the changes were committed.
+            - dict: JSON-encoded representation of the updated executive role.
+    """
+    executive_role = validate_id(session, ExecutiveRole, id, ExecutiveRole.id)
+
+    update_data = form_param.model_dump(exclude_unset=True)
+
+    update_if_changed(executive_role, update_data)
+    updated = session.is_modified(executive_role)
+    if updated:
+        session.commit()
+        session.refresh(executive_role)
+    return updated, jsonable_encoder(executive_role)
+
+
+def search_executive_roles(
+    session: Session, query_params: QueryParams
+) -> List[ExecutiveRole]:
+    """
+    Searches for executive roles based on the provided query parameters.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        query_params (QueryParams): Query parameters for filtering, searching, and pagination.
+
+    Returns:
+        List[ExecutiveRole]: List of executive roles matching the search criteria.
+    """
+    query = session.query(ExecutiveRole)
+
+    # Common search
+    if query_params.search:
+        search = f"%{query_params.search}%"
+        query = query.filter(
+            or_(
+                ExecutiveRole.id.cast(String).ilike(search),
+                ExecutiveRole.name.ilike(search),
+            )
+        )
+
+    # Generalized filters
+    query = apply_id_filters(query, ExecutiveRole, query_params)
+    query = apply_created_on_filters(query, ExecutiveRole, query_params)
+    query = apply_updated_on_filters(query, ExecutiveRole, query_params)
+    query = apply_name_filters(query, ExecutiveRole, query_params)
+
+    # Ordering and pagination
+    ordering_attr = getattr(ExecutiveRole, query_params.order_by.value)
+    ordering_func = (
+        ordering_attr.asc()
+        if query_params.order_in == OrderIn.ASCENDING
+        else ordering_attr.desc()
+    )
+    query = query.order_by(ordering_func())
+    query = query.offset(query_params.offset).limit(query_params.limit)
+
+    executive_roles = query.all()
+    return executive_roles
+
+
+def delete_executive_role(session: Session, id: int) -> tuple[bool, dict]:
+    """
+    Delete an executive role from the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        id (int): ID of the executive role to delete.
+
+    Returns:
+        Tuple[bool, dict]:
+            - bool: True if the executive role was found and deleted, False otherwise.
+            - dict: JSON-encoded representation of the deleted executive role, or an empty dictionary if not found.
+    """
+    executive_role = session.query(ExecutiveRole).filter(ExecutiveRole.id == id).first()
+    if executive_role is not None:
+        executive_role_data = jsonable_encoder(executive_role)
+        session.delete(executive_role)
+        session.commit()
+        return True, executive_role_data
+    return False, {}
+
+
+# ---------------------------------------------------------------------------
 ## Common exceptions
 # ---------------------------------------------------------------------------
 POST_EXCEPTIONS = [
@@ -174,22 +299,9 @@ async def create_executive_role_for_executive(
             session, access_token, [PermissionPath.CREATE_EXECUTIVE_ROLE]
         )
 
-        role_count = session.query(ExecutiveRole).count()
-        if role_count >= MAX_EXECUTIVE_ROLE:
-            raise exceptions.LimitExceeded(ExecutiveRole)
-
-        form_param.permissions = form_param.permissions.model_dump()
-        role = ExecutiveRole(
-            name=form_param.name,
-            permissions=form_param.permissions,
-        )
-        session.add(role)
-        session.commit()
-        session.refresh(role)
-
-        role_data = jsonable_encoder(role)
-        log_event(token, request_info, role_data)
-        return role_data
+        executive_role_data = create_executive_role(session, form_param)
+        log_event(token, request_info, executive_role_data)
+        return executive_role_data
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -217,18 +329,10 @@ async def update_executive_role_for_executive(
             session, access_token, [PermissionPath.UPDATE_EXECUTIVE_ROLE]
         )
 
-        role = validate_id(session, ExecutiveRole, id, ExecutiveRole.id)
-        update_data = form_param.model_dump(exclude_unset=True)
-        update_if_changed(role, update_data)
-        have_updates = session.is_modified(role)
-        if have_updates:
-            session.commit()
-            session.refresh(role)
-
-        role_data = jsonable_encoder(role)
-        if have_updates:
-            log_event(token, request_info, role_data)
-        return role_data
+        updated, executive_role_data = update_executive_role(session, id, form_param)
+        if updated:
+            log_event(token, request_info, executive_role_data)
+        return executive_role_data
     except Exception as e:
         exceptions.handle(e)
     finally:
@@ -254,12 +358,9 @@ async def delete_executive_role_for_executive(
             session, access_token, [PermissionPath.DELETE_EXECUTIVE_ROLE]
         )
 
-        role = session.query(ExecutiveRole).filter(ExecutiveRole.id == id).first()
-        if role is not None:
-            role_data = jsonable_encoder(role)
-            session.delete(role)
-            session.commit()
-            log_event(token, request_info, role_data)
+        deleted, executive_role_data = delete_executive_role(session, id)
+        if deleted:
+            log_event(token, request_info, executive_role_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)
@@ -283,36 +384,7 @@ async def fetch_executive_roles_for_executive(
         session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
 
-        query = session.query(ExecutiveRole)
-
-        # Common search
-        if query_params.search:
-            search = f"%{query_params.search}%"
-            query = query.filter(
-                or_(
-                    ExecutiveRole.id.cast(String).ilike(search),
-                    ExecutiveRole.name.ilike(search),
-                )
-            )
-
-        # Generalized filters
-        query = apply_id_filters(query, ExecutiveRole, query_params)
-        query = apply_created_on_filters(query, ExecutiveRole, query_params)
-        query = apply_updated_on_filters(query, ExecutiveRole, query_params)
-        query = apply_name_filters(query, ExecutiveRole, query_params)
-
-        # Ordering and pagination
-        ordering_attr = getattr(ExecutiveRole, query_params.order_by.value)
-        ordering_func = (
-            ordering_attr.asc
-            if query_params.order_in == OrderIn.ASCENDING
-            else ordering_attr.desc
-        )
-        query = query.order_by(ordering_func())
-        query = query.offset(query_params.offset).limit(query_params.limit)
-
-        roles = query.all()
-        return roles
+        return search_executive_roles(session, query_params)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/api/executive_role.py
+++ b/app/api/executive_role.py
@@ -190,9 +190,9 @@ def search_executive_roles(
     # Ordering and pagination
     ordering_attr = getattr(ExecutiveRole, query_params.order_by.value)
     ordering_func = (
-        ordering_attr.asc()
+        ordering_attr.asc
         if query_params.order_in == OrderIn.ASCENDING
-        else ordering_attr.desc()
+        else ordering_attr.desc
     )
     query = query.order_by(ordering_func())
     query = query.offset(query_params.offset).limit(query_params.limit)

--- a/app/api/executive_role_map.py
+++ b/app/api/executive_role_map.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Response, status, Depends, Query
 from enum import StrEnum
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
+from sqlalchemy.orm.session import Session
 
 from app.api.bearer import oauth2_executive
 from app.src.db import (
@@ -89,6 +90,128 @@ class QueryParams(UpdatedOnFilter, CreatedOnFilter, IDFilter, PaginationFilter):
     order_in: OrderIn = Field(
         Query(default=OrderIn.DESCENDING, description=enum_str(OrderIn))
     )
+
+
+# ---------------------------------------------------------------------------
+## Core Functions
+# ---------------------------------------------------------------------------
+def create_executive_role_map(session: Session, form_param: CreateForm) -> dict:
+    """
+    Creates a new executive role mapping with the provided form data.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        form_param (CreateForm): Form data for creating a new executive role mapping.
+
+    Returns:
+        dict: Created executive role mapping data.
+    """
+    validate_id(
+        session, Executive, form_param.executive_id, ExecutiveRoleMap.executive_id
+    )
+    validate_id(session, ExecutiveRole, form_param.role_id, ExecutiveRoleMap.role_id)
+
+    role_map = ExecutiveRoleMap(
+        role_id=form_param.role_id, executive_id=form_param.executive_id
+    )
+    session.add(role_map)
+    session.commit()
+    session.refresh(role_map)
+    return jsonable_encoder(role_map)
+
+
+def update_executive_role_map(
+    session: Session, id: int, form_param: UpdateForm
+) -> tuple[bool, dict]:
+    """
+    Updates an Executive role mapping with the provided form data.
+
+    Args:
+        session (Session): SQLAlchemy database session.
+        id (int): ID of the executive role mapping to update.
+        form_param (UpdateForm): Form data containing fields to update.
+
+    Returns:
+        Tuple[bool, dict]:
+            - bool: True if the executive role mapping was modified and the changes were committed.
+            - dict: JSON-encoded representation of the updated executive role mapping.
+    """
+    role_map = validate_id(session, ExecutiveRoleMap, id, ExecutiveRoleMap.id)
+
+    update_data = form_param.model_dump(exclude_unset=True)
+    if "role_id" in update_data:
+        if role_map.role_id != form_param.role_id:
+            validate_id(
+                session, ExecutiveRole, form_param.role_id, ExecutiveRoleMap.role_id
+            )
+            role_map.role_id = form_param.role_id
+            update_data.pop("role_id")
+
+    updated = session.is_modified(role_map)
+    if updated:
+        session.commit()
+        session.refresh(role_map)
+    return updated, jsonable_encoder(role_map)
+
+
+def search_executive_role_maps(
+    session: Session, query_params: QueryParams
+) -> list[ExecutiveRoleMap]:
+    """
+    Searches for executive role mappings based on the provided query parameters.
+
+    Args:
+        session (Session): SQLAlchemy database session.
+        query_params (QueryParams): Query parameters for filtering and pagination.
+
+    Returns:
+        list[ExecutiveRoleMap]: List of executive role mappings matching the query parameters.
+    """
+    query = session.query(ExecutiveRoleMap)
+    if query_params.role_id is not None:
+        query = query.filter(ExecutiveRoleMap.role_id == query_params.role_id)
+    if query_params.executive_id is not None:
+        query = query.filter(ExecutiveRoleMap.executive_id == query_params.executive_id)
+
+    # Generalized filters
+    query = apply_id_filters(query, ExecutiveRoleMap, query_params)
+    query = apply_created_on_filters(query, ExecutiveRoleMap, query_params)
+    query = apply_updated_on_filters(query, ExecutiveRoleMap, query_params)
+
+    # Ordering and pagination
+    ordering_attr = getattr(ExecutiveRoleMap, query_params.order_by.value)
+    ordering_func = (
+        ordering_attr.asc
+        if query_params.order_in == OrderIn.ASCENDING
+        else ordering_attr.desc
+    )
+    query = query.order_by(ordering_func())
+    query = query.offset(query_params.offset).limit(query_params.limit)
+
+    role_maps = query.all()
+    return role_maps
+
+
+def delete_executive_role_map(session: Session, id: int) -> tuple[bool, dict]:
+    """
+    Deletes an executive role mapping from the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        id (int): ID of the executive role mapping to delete.
+
+    Returns:
+        Tuple[bool, dict]:
+            - bool: True if the executive role mapping was found and deleted.
+            - dict: JSON-encoded representation of the deleted executive role mapping.
+    """
+    role_map = session.query(ExecutiveRoleMap).filter(ExecutiveRoleMap.id == id).first()
+    if role_map is not None:
+        role_map_data = jsonable_encoder(role_map)
+        session.delete(role_map)
+        session.commit()
+        return True, role_map_data
+    return False, {}
 
 
 # ---------------------------------------------------------------------------
@@ -171,20 +294,7 @@ async def create_executive_role_map_for_executive(
             session, access_token, [PermissionPath.UPDATE_EXECUTIVE_ROLE]
         )
 
-        validate_id(
-            session, Executive, form_param.executive_id, ExecutiveRoleMap.executive_id
-        )
-        validate_id(
-            session, ExecutiveRole, form_param.role_id, ExecutiveRoleMap.role_id
-        )
-        role_map = ExecutiveRoleMap(
-            role_id=form_param.role_id, executive_id=form_param.executive_id
-        )
-        session.add(role_map)
-        session.commit()
-        session.refresh(role_map)
-
-        role_map_data = jsonable_encoder(role_map)
+        role_map_data = create_executive_role_map(session, form_param)
         log_event(token, request_info, role_map_data)
         return role_map_data
     except Exception as e:
@@ -214,20 +324,8 @@ async def update_executive_role_map_for_executive(
             session, access_token, [PermissionPath.UPDATE_EXECUTIVE_ROLE]
         )
 
-        role_map = validate_id(session, ExecutiveRoleMap, id, ExecutiveRoleMap.id)
-        if form_param.role_id is not None and role_map.role_id != form_param.role_id:
-            validate_id(
-                session, ExecutiveRole, form_param.role_id, ExecutiveRoleMap.role_id
-            )
-            role_map.role_id = form_param.role_id
-
-        have_updates = session.is_modified(role_map)
-        if have_updates:
-            session.commit()
-            session.refresh(role_map)
-
-        role_map_data = jsonable_encoder(role_map)
-        if have_updates:
+        updated, role_map_data = update_executive_role_map(session, id, form_param)
+        if updated:
             log_event(token, request_info, role_map_data)
         return role_map_data
     except Exception as e:
@@ -255,13 +353,8 @@ async def delete_executive_role_map_for_executive(
             session, access_token, [PermissionPath.UPDATE_EXECUTIVE_ROLE]
         )
 
-        role_map = (
-            session.query(ExecutiveRoleMap).filter(ExecutiveRoleMap.id == id).first()
-        )
-        if role_map is not None:
-            role_map_data = jsonable_encoder(role_map)
-            session.delete(role_map)
-            session.commit()
+        deleted, role_map_data = delete_executive_role_map(session, id)
+        if deleted:
             log_event(token, request_info, role_map_data)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
@@ -286,31 +379,7 @@ async def fetch_executive_role_maps_for_executive(
         session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
 
-        query = session.query(ExecutiveRoleMap)
-        if query_params.role_id is not None:
-            query = query.filter(ExecutiveRoleMap.role_id == query_params.role_id)
-        if query_params.executive_id is not None:
-            query = query.filter(
-                ExecutiveRoleMap.executive_id == query_params.executive_id
-            )
-
-        # Generalized filters
-        query = apply_id_filters(query, ExecutiveRoleMap, query_params)
-        query = apply_created_on_filters(query, ExecutiveRoleMap, query_params)
-        query = apply_updated_on_filters(query, ExecutiveRoleMap, query_params)
-
-        # Ordering and pagination
-        ordering_attr = getattr(ExecutiveRoleMap, query_params.order_by.value)
-        ordering_func = (
-            ordering_attr.asc
-            if query_params.order_in == OrderIn.ASCENDING
-            else ordering_attr.desc
-        )
-        query = query.order_by(ordering_func())
-        query = query.offset(query_params.offset).limit(query_params.limit)
-
-        role_maps = query.all()
-        return role_maps
+        return search_executive_role_maps(session, query_params)
     except Exception as e:
         exceptions.handle(e)
     finally:

--- a/app/src/functions.py
+++ b/app/src/functions.py
@@ -515,7 +515,7 @@ def get_area(geom: BaseGeometry) -> float:
     return projected_geom.area
 
 
-T = TypeVar("T", bound="BaseModel")
+T = TypeVar("T", bound=BaseModel)
 
 
 def resolve_model_defaults(model_cls: Type[T], **overrides) -> T:

--- a/app/src/functions.py
+++ b/app/src/functions.py
@@ -8,7 +8,7 @@ import pyproj
 from enum import Enum
 from io import BytesIO
 from PIL import Image
-from typing import Any, List, Dict, Type, Union
+from typing import Any, List, Dict, Type, TypeVar, Union
 from fastapi import Query, Request
 from pydantic import BaseModel
 from sqlalchemy import Column, asc, desc
@@ -515,16 +515,19 @@ def get_area(geom: BaseGeometry) -> float:
     return projected_geom.area
 
 
-def resolve_model_defaults(model_cls: Type[BaseModel], **overrides):
+T = TypeVar("T", bound="BaseModel")
+
+
+def resolve_model_defaults(model_cls: Type[T], **overrides) -> T:
     """
     Build a model instance with all Query() defaults resolved to concrete values.
 
     Args:
-        model_cls (Type[BaseModel]): The Pydantic model class to build.
+        model_cls (Type[T]): The Pydantic model class to build.
         **overrides: Field values to override the defaults.
 
     Returns:
-        BaseModel: An instance of model_cls with all Query() defaults resolved.
+        T: An instance of model_cls with all Query() defaults resolved.
     """
     data = {}
     for field_name, field_info in model_cls.model_fields.items():

--- a/app/src/validators.py
+++ b/app/src/validators.py
@@ -497,7 +497,7 @@ def is_valid_transition(
     return new_state in transitions[old_state]
 
 
-T = TypeVar("T", bound="ORMbase")
+T = TypeVar("T", bound=ORMbase)
 
 
 def validate_id(


### PR DESCRIPTION
### **Summary of Changes**
This PR refactors multiple FastAPI routers by moving CRUD/search logic into reusable core functions.
* Reason for the change?
  * Endpoint handlers currently contain duplicated CRUD and search logic, making the code harder to maintain and extend.
  * Response formatting and side-effect handling were inconsistent across routers, especially for geometry fields and object-storage cleanup.

* What changed?
  * Extracted reusable core CRUD/search functions from FastAPI router endpoints.
  * Added shared core functions for multiple resources, including:

    * Executive roles
    * Role maps
    * Executives
    * Duties
    * Companies
    * Businesses
    * Bus stops
  * Updated endpoints to delegate operations to the new core functions.
  * Standardised geometry serialisation by introducing `*_to_dict()` helper methods and using them in API responses where location data requires dictionary formatting.
  * Improved delete workflows by adding object-storage cleanup for additional related images, including vehicle images and multiple executive images.
  * Standardised logging behaviour across the refactored flows.

### **How to Test / Verify**
1. Verify existing CRUD operations for the affected resources:
   * Create a resource.
   * Update an existing resource.
   * Get/list resources.
   * Delete resources.
2. Confirm API responses remain unchanged and geometry/location fields are returned in the expected dictionary format.
3. Validate that the extracted core functions are correctly invoked by the corresponding endpoints.
4. Delete resources containing related images and verify associated object-storage files are cleaned up.
5. Review application logs to ensure expected logging behavior is maintained.

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.

### **Additional Notes (Optional)**
N/A

### **Reviewer Notes**
N/A
