### PR TITLE
Enforce maximum location points per trace in location creation

### DIFF
--- a/app/api/location_in_trace.py
+++ b/app/api/location_in_trace.py
@@ -23,6 +23,7 @@ from app.src.db import (
     Trace,
 )
 from app.src.description import Description
+from app.src.constants import MAX_LOCATIONS_PER_TRACES
 from app.src.enums import LocationType, OrderIn
 from app.src.filters import (
     CreatedOnFilter,
@@ -176,6 +177,14 @@ def create_location_in_trace(
             geometry = validate_wkt_string(location, Point)
             validate_srid_4326(geometry)
 
+            location_count = (
+                session.query(LocationInTrace)
+                .filter(LocationInTrace.trace_id == form_param.trace_id)
+                .count()
+            )
+            if location_count >= MAX_LOCATIONS_PER_TRACES:
+                raise exceptions.LimitExceeded(LocationInTrace)
+            
             location_in_trace = LocationInTrace(
                 trace_id=form_param.trace_id,
                 company_id=trace.company_id,
@@ -259,6 +268,7 @@ POST_EXCEPTIONS = [
     exceptions.InvalidWKTStringOrType(),
     exceptions.InvalidSRID4326(),
     exceptions.UnknownValue(LocationInTrace.trace_id),
+    exceptions.LimitExceeded(LocationInTrace),
 ]
 
 GET_EXCEPTIONS = [
@@ -278,6 +288,7 @@ POST_DESCRIPTION = (
     .add_line("Use WGS84 compatible coordinates within SRID 4326 bounds.")
     .add_line("Supports batch uploads")
     .add_line("A maximum of 50 locations can be uploaded in a single batch upload.")
+    .add_line(f"A maximum of {MAX_LOCATIONS_PER_TRACES} locations can be associated with a single trace.")
 )
 
 GET_DESCRIPTION = (

--- a/app/api/location_in_trace.py
+++ b/app/api/location_in_trace.py
@@ -184,7 +184,7 @@ def create_location_in_trace(
             )
             if location_count >= MAX_LOCATIONS_PER_TRACES:
                 raise exceptions.LimitExceeded(LocationInTrace)
-            
+
             location_in_trace = LocationInTrace(
                 trace_id=form_param.trace_id,
                 company_id=trace.company_id,
@@ -288,7 +288,9 @@ POST_DESCRIPTION = (
     .add_line("Use WGS84 compatible coordinates within SRID 4326 bounds.")
     .add_line("Supports batch uploads")
     .add_line("A maximum of 50 locations can be uploaded in a single batch upload.")
-    .add_line(f"A maximum of {MAX_LOCATIONS_PER_TRACES} locations can be associated with a single trace.")
+    .add_line(
+        f"A maximum of {MAX_LOCATIONS_PER_TRACES} locations can be associated with a single trace."
+    )
 )
 
 GET_DESCRIPTION = (

--- a/app/api/location_in_trace.py
+++ b/app/api/location_in_trace.py
@@ -23,7 +23,7 @@ from app.src.db import (
     Trace,
 )
 from app.src.description import Description
-from app.src.constants import MAX_LOCATIONS_PER_TRACES
+from app.src.constants import MAX_LOCATIONS_PER_TRACE
 from app.src.enums import LocationType, OrderIn
 from app.src.filters import (
     CreatedOnFilter,
@@ -172,19 +172,17 @@ def create_location_in_trace(
         LocationInTrace.trace_id,
         extra_filter=extra_filter_for_trace,
     )
+    location_count = (
+        session.query(LocationInTrace)
+        .filter(LocationInTrace.trace_id == form_param.trace_id)
+        .count()
+    )
+    if location_count >= MAX_LOCATIONS_PER_TRACE:
+        raise exceptions.LimitExceeded(LocationInTrace)
     for location_data in form_param.trace_locations:
         for location in location_data.locations:
             geometry = validate_wkt_string(location, Point)
             validate_srid_4326(geometry)
-
-            location_count = (
-                session.query(LocationInTrace)
-                .filter(LocationInTrace.trace_id == form_param.trace_id)
-                .count()
-            )
-            if location_count >= MAX_LOCATIONS_PER_TRACES:
-                raise exceptions.LimitExceeded(LocationInTrace)
-
             location_in_trace = LocationInTrace(
                 trace_id=form_param.trace_id,
                 company_id=trace.company_id,
@@ -289,7 +287,7 @@ POST_DESCRIPTION = (
     .add_line("Supports batch uploads")
     .add_line("A maximum of 50 locations can be uploaded in a single batch upload.")
     .add_line(
-        f"A maximum of {MAX_LOCATIONS_PER_TRACES} locations can be associated with a single trace."
+        f"A maximum of {MAX_LOCATIONS_PER_TRACE} locations can be associated with a single trace."
     )
 )
 

--- a/app/api/location_in_trace.py
+++ b/app/api/location_in_trace.py
@@ -172,6 +172,7 @@ def create_location_in_trace(
         LocationInTrace.trace_id,
         extra_filter=extra_filter_for_trace,
     )
+
     location_count = (
         session.query(LocationInTrace)
         .filter(LocationInTrace.trace_id == form_param.trace_id)
@@ -179,6 +180,7 @@ def create_location_in_trace(
     )
     if location_count >= MAX_LOCATIONS_PER_TRACE:
         raise exceptions.LimitExceeded(LocationInTrace)
+    
     for location_data in form_param.trace_locations:
         for location in location_data.locations:
             geometry = validate_wkt_string(location, Point)

--- a/app/api/location_in_trace.py
+++ b/app/api/location_in_trace.py
@@ -180,7 +180,7 @@ def create_location_in_trace(
     )
     if location_count >= MAX_LOCATIONS_PER_TRACE:
         raise exceptions.LimitExceeded(LocationInTrace)
-    
+
     for location_data in form_param.trace_locations:
         for location in location_data.locations:
             geometry = validate_wkt_string(location, Point)

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -140,6 +140,7 @@ MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company
 MAX_LOCAL_FARES_PER_COMPANY = 50  # Maximum LOCAL fares per company
 MAX_VEHICLES_PER_COMPANY = 100  # Maximum vehicles per company
 MAX_TRACES_PER_COMPANY = 100  # Maximum traces per company
+MAX_LOCATIONS_PER_TRACES = 65536 # Maximum locations per trace
 
 
 # ---------------------------------------------------------------------------

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -139,7 +139,7 @@ MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company
 MAX_LOCAL_FARES_PER_COMPANY = 50  # Maximum LOCAL fares per company
 MAX_VEHICLES_PER_COMPANY = 100  # Maximum vehicles per company
 MAX_TRACES_PER_COMPANY = 100  # Maximum traces per company
-MAX_LOCATIONS_PER_TRACES = 65536  # Maximum locations per trace
+MAX_LOCATIONS_PER_TRACE = 65536  # Maximum locations per trace
 
 
 # ---------------------------------------------------------------------------

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -10,7 +10,6 @@ Configuration values can be overridden via environment variables.
 from os import environ
 from zoneinfo import ZoneInfo
 
-
 # ---------------------------------------------------------------------------
 # Application metadata
 # ---------------------------------------------------------------------------
@@ -140,7 +139,7 @@ MAX_OPERATORS_PER_COMPANY = 100  # Maximum operators per company
 MAX_LOCAL_FARES_PER_COMPANY = 50  # Maximum LOCAL fares per company
 MAX_VEHICLES_PER_COMPANY = 100  # Maximum vehicles per company
 MAX_TRACES_PER_COMPANY = 100  # Maximum traces per company
-MAX_LOCATIONS_PER_TRACES = 65536 # Maximum locations per trace
+MAX_LOCATIONS_PER_TRACES = 65536  # Maximum locations per trace
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
Reason for the change?
- Restricted the number of locations that can be created for a trace.

What changed? 
- Enforced a maximum limit of 65,536 locations per trace and prevented new location creation after the configured limit was reached.

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Set MAX_LOCATIONS_PER_TRACES= 3 for easier API testing.
- Create the first 3 locations for the same trace_id.
- Verify that all 3 locations are created successfully.
- Attempt to create a 4th location for the same trace_id.
- Verify the correct limit-exceeded response is returned.



### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
NA

### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
