### PR TITLE
Enforce a per-bus-stop limit on landmarks by adding MAX_BUS_STOPS_PER…

### DIFF
--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -41,6 +41,7 @@ from app.src.regex import NAME_PATTERN
 from app.src.urls import URL_BUS_STOP
 from app.src.openobserve import log_event
 from app.src.description import Description
+from app.src.constants import MAX_BUS_STOPS_PER_LANDMARK
 from app.src.validators import (
     verify_token,
     validate_id,
@@ -209,6 +210,14 @@ def create_bus_stop(session: Session, form_param: CreateForm) -> dict:
     Returns:
         dict: Created bus stop data with location in WKT format.
     """
+    bus_stop_count = (
+        session.query(BusStop)
+        .filter(BusStop.landmark_id == form_param.landmark_id)
+        .count()
+    )
+    if bus_stop_count >= MAX_BUS_STOPS_PER_LANDMARK:
+        raise exceptions.LimitExceeded(BusStop)
+
     # Validate location (WKT, SRID, and landmark boundary)
     location_geom = validate_location(
         session, form_param.location, form_param.landmark_id
@@ -353,6 +362,7 @@ POST_EXCEPTIONS = [
     exceptions.InvalidSRID4326(),
     exceptions.UnknownValue(BusStop.landmark_id),
     exceptions.BusStopOutsideLandmark(),
+    exceptions.LimitExceeded(BusStop),
 ]
 
 PATCH_EXCEPTIONS = [
@@ -387,6 +397,9 @@ POST_DESCRIPTION = (
     .add_line("Use WGS84 compatible coordinates within SRID 4326 bounds.")
     .add_line("The location must be within the boundary of the landmark.")
     .add_line("Logged-in executive must have `landmark.bus_stop.create` permission.")
+    .add_line(
+        f"A maximum of {MAX_BUS_STOPS_PER_LANDMARK} bus stops are allowed per landmark."
+    )
 )
 
 PATCH_DESCRIPTION = (

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -83,6 +83,7 @@ MAX_LANDMARK_UPDATE_DISTANCE = 1000  # 1 km
 MIN_LANDMARKS_PER_ROUTE = 2  # Minimum number of landmarks per route
 MAX_LANDMARKS_PER_ROUTE = 100  # # Maximum number of landmarks per route
 MAX_ROUTE_DISTANCE = 10000 * 1000  # Maximum  route length in meters (10000 km)
+MAX_BUS_STOPS_PER_LANDMARK = 20  # Maximum number of bus stops per landmark
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
Reason for the change?

- Restricted the number of bus stops that can be created on a landmark.

 What changed? 

- Enforced a maximum limit of 20 bus stops per landmark and prevented new bus stop creation after the configured limit was reached.


### **How to Test / Verify**

- Set MAX_BUS_STOPS_PER_LANDMARK= 3 for easier API testing.
- Create the first 3 bus stops for the same landmark.
- Verify that all 3 bus stops are created successfully.
- Attempt to create a 4th bus stop for the same landmark.
- Verify the correct limit-exceeded response is returned.

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
N/A


### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
