### PR TITLE
Add executive role mapping CRUD support with permission-based access

### DIFF
--- a/app/api/bus_stop.py
+++ b/app/api/bus_stop.py
@@ -291,7 +291,7 @@ def update_bus_stop(
 
 def delete_bus_stop(
     session: Session, id: int, token: ExecutiveToken, request_info: schemas.RequestInfo
-):
+) -> None:
     """
     Delete a bus stop from the database.
 

--- a/app/api/executive_role.py
+++ b/app/api/executive_role.py
@@ -181,7 +181,7 @@ def delete_executive_role(
     id: int,
     token: ExecutiveToken,
     request_info: schemas.RequestInfo,
-):
+) -> None:
     """
     Delete an executive role from the database.
 

--- a/app/api/executive_role.py
+++ b/app/api/executive_role.py
@@ -1,22 +1,23 @@
 """
-Executive Role API Router for EnteBus.
+Executive Role API router.
 
-Provides endpoints for managing executive roles, including creation,
-update, deletion, and retrieval. Uses Pydantic schemas for
-input validation and structured output.
+Provides endpoints for managing executive roles:
+    - POST (executive)
+    - PATCH (executive)
+    - DELETE (executive)
+    - GET (executive)
 """
 
 from datetime import datetime
 from enum import StrEnum
-from typing import List
-from fastapi import APIRouter, Query, Response, status, Depends
+from fastapi import APIRouter, Depends, Query, Response, status
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from sqlalchemy import or_, String
 from sqlalchemy.orm.session import Session
 
 from app.api.bearer import oauth2_executive
-from app.src.db import ExecutiveRole, ExecutiveToken, SessionLocal
+from app.src.db import ExecutiveRole, ExecutiveToken, get_db_session
 from app.src.enums import OrderIn
 from app.src.filters import (
     CreatedOnFilter,
@@ -26,7 +27,8 @@ from app.src.filters import (
     NameFilter,
 )
 from app.src.permissions.executive import PermissionSchema, PermissionPath
-from app.src import exceptions
+from app.src import exceptions, schemas
+from app.src.schemas import PatchForm
 from app.src.regex import NAME_PATTERN
 from app.src.urls import URL_EXECUTIVE_ROLE
 from app.src.openobserve import log_event
@@ -56,8 +58,8 @@ class ExecutiveRoleSchema(BaseModel):
     id: int
     name: str
     permissions: PermissionSchema
-    created_on: datetime
     updated_on: datetime | None
+    created_on: datetime
 
 
 # ---------------------------------------------------------------------------
@@ -70,11 +72,13 @@ class CreateForm(BaseModel):
     permissions: PermissionSchema
 
 
-class UpdateForm(BaseModel):
+class UpdateForm(PatchForm):
     """Form data for updating an executive role."""
 
-    name: str = Field(default=None, min_length=1, max_length=32, pattern=NAME_PATTERN)
-    permissions: PermissionSchema = Field(default=None)
+    name: str | None = Field(
+        default=None, min_length=1, max_length=32, pattern=NAME_PATTERN
+    )
+    permissions: PermissionSchema | None = Field(default=None)
 
 
 # ---------------------------------------------------------------------------
@@ -103,13 +107,20 @@ class QueryParams(
 # ---------------------------------------------------------------------------
 ## Core Functions
 # ---------------------------------------------------------------------------
-def create_executive_role(session: Session, form_param: CreateForm) -> dict:
+def create_executive_role(
+    session: Session,
+    form_param: CreateForm,
+    token: ExecutiveToken,
+    request_info: schemas.RequestInfo,
+) -> dict:
     """
     Creates a new executive role with the provided form data.
 
     Args:
         session (Session): Active SQLAlchemy database session.
         form_param (CreateForm): Form data for creating a new executive role.
+        token (ExecutiveToken): Authenticated executive token.
+        request_info (schemas.RequestInfo): Request information for logging.
 
     Returns:
         dict: Created executive role data.
@@ -125,12 +136,19 @@ def create_executive_role(session: Session, form_param: CreateForm) -> dict:
     session.add(executive_role)
     session.commit()
     session.refresh(executive_role)
-    return jsonable_encoder(executive_role)
+
+    executive_role_data = jsonable_encoder(executive_role)
+    log_event(token, request_info, executive_role_data)
+    return executive_role_data
 
 
 def update_executive_role(
-    session: Session, id: int, form_param: UpdateForm
-) -> tuple[bool, dict]:
+    session: Session,
+    id: int,
+    form_param: UpdateForm,
+    token: ExecutiveToken,
+    request_info: schemas.RequestInfo,
+) -> dict:
     """
     Updates an ExecutiveRole with the provided form data.
 
@@ -138,36 +156,66 @@ def update_executive_role(
         session (Session): SQLAlchemy database session.
         id (int): ID of the executive role to update.
         form_param (UpdateForm): Form data containing fields to update.
+        token (ExecutiveToken): Authenticated executive token.
+        request_info (schemas.RequestInfo): Request information for logging.
 
     Returns:
-        Tuple[bool, dict]:
-            - bool: True if the executive role was modified and the changes were committed.
-            - dict: JSON-encoded representation of the updated executive role.
+        dict: Updated executive role data.
     """
     executive_role = validate_id(session, ExecutiveRole, id, ExecutiveRole.id)
 
     update_data = form_param.model_dump(exclude_unset=True)
-
     update_if_changed(executive_role, update_data)
-    updated = session.is_modified(executive_role)
-    if updated:
+    if session.is_modified(executive_role):
         session.commit()
         session.refresh(executive_role)
-    return updated, jsonable_encoder(executive_role)
+        executive_role_data = jsonable_encoder(executive_role)
+        log_event(token, request_info, executive_role_data)
+    else:
+        executive_role_data = jsonable_encoder(executive_role)
+    return executive_role_data
+
+
+def delete_executive_role(
+    session: Session,
+    id: int,
+    token: ExecutiveToken,
+    request_info: schemas.RequestInfo,
+):
+    """
+    Delete an executive role from the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        id (int): ID of the executive role to delete.
+        token (ExecutiveToken): Authenticated executive token.
+        request_info (schemas.RequestInfo): Request information for logging.
+    """
+    executive_role = session.query(ExecutiveRole).filter(ExecutiveRole.id == id).first()
+    if executive_role is None:
+        return
+
+    executive_role_data = jsonable_encoder(executive_role)
+    session.delete(executive_role)
+    session.commit()
+    log_event(token, request_info, executive_role_data)
 
 
 def search_executive_roles(
     session: Session, query_params: QueryParams
-) -> List[ExecutiveRole]:
+) -> list[ExecutiveRole]:
     """
     Searches for executive roles based on the provided query parameters.
+
+    This function supports multiple filtering, searching, ordering, and
+    pagination capabilities to retrieve executive roles that match various criteria.
 
     Args:
         session (Session): Active SQLAlchemy database session.
         query_params (QueryParams): Query parameters for filtering, searching, and pagination.
 
     Returns:
-        List[ExecutiveRole]: List of executive roles matching the search criteria.
+        list[ExecutiveRole]: List of executive roles matching the search criteria.
     """
     query = session.query(ExecutiveRole)
 
@@ -199,28 +247,6 @@ def search_executive_roles(
 
     executive_roles = query.all()
     return executive_roles
-
-
-def delete_executive_role(session: Session, id: int) -> tuple[bool, dict]:
-    """
-    Delete an executive role from the database.
-
-    Args:
-        session (Session): Active SQLAlchemy database session.
-        id (int): ID of the executive role to delete.
-
-    Returns:
-        Tuple[bool, dict]:
-            - bool: True if the executive role was found and deleted, False otherwise.
-            - dict: JSON-encoded representation of the deleted executive role, or an empty dictionary if not found.
-    """
-    executive_role = session.query(ExecutiveRole).filter(ExecutiveRole.id == id).first()
-    if executive_role is not None:
-        executive_role_data = jsonable_encoder(executive_role)
-        session.delete(executive_role)
-        session.commit()
-        return True, executive_role_data
-    return False, {}
 
 
 # ---------------------------------------------------------------------------
@@ -292,20 +318,15 @@ async def create_executive_role_for_executive(
     form_param: CreateForm,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         token = authorize_executive(
             session, access_token, [PermissionPath.CREATE_EXECUTIVE_ROLE]
         )
-
-        executive_role_data = create_executive_role(session, form_param)
-        log_event(token, request_info, executive_role_data)
-        return executive_role_data
+        return create_executive_role(session, form_param, token, request_info)
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()
 
 
 @route_executive.patch(
@@ -322,21 +343,15 @@ async def update_executive_role_for_executive(
     form_param: UpdateForm,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         token = authorize_executive(
             session, access_token, [PermissionPath.UPDATE_EXECUTIVE_ROLE]
         )
-
-        updated, executive_role_data = update_executive_role(session, id, form_param)
-        if updated:
-            log_event(token, request_info, executive_role_data)
-        return executive_role_data
+        return update_executive_role(session, id, form_param, token, request_info)
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()
 
 
 @route_executive.delete(
@@ -351,21 +366,16 @@ async def delete_executive_role_for_executive(
     id: int,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         token = authorize_executive(
             session, access_token, [PermissionPath.DELETE_EXECUTIVE_ROLE]
         )
-
-        deleted, executive_role_data = delete_executive_role(session, id)
-        if deleted:
-            log_event(token, request_info, executive_role_data)
+        delete_executive_role(session, id, token, request_info)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()
 
 
 @route_executive.get(
@@ -379,13 +389,10 @@ async def delete_executive_role_for_executive(
 async def fetch_executive_roles_for_executive(
     query_params: QueryParams = Depends(),
     access_token=Depends(oauth2_executive),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
-
         return search_executive_roles(session, query_params)
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()

--- a/app/api/executive_role_map.py
+++ b/app/api/executive_role_map.py
@@ -1,14 +1,16 @@
 """
-Executive Role Map API Router for EnteBus.
+Executive Role Map API router.
 
-Provides endpoints for managing executive role mappings, including creation,
-update, deletion, and retrieval. Uses Pydantic schemas for
-input validation and structured output.
+Provides endpoints for managing executive role maps:
+    - POST (executive)
+    - PATCH (executive)
+    - DELETE (executive)
+    - GET (executive)
 """
 
 from datetime import datetime
-from fastapi import APIRouter, Response, status, Depends, Query
 from enum import StrEnum
+from fastapi import APIRouter, Depends, Query, Response, status
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from sqlalchemy.orm.session import Session
@@ -16,16 +18,17 @@ from sqlalchemy.orm.session import Session
 from app.api.bearer import oauth2_executive
 from app.src.db import (
     Executive,
+    ExecutiveRole,
     ExecutiveRoleMap,
     ExecutiveToken,
-    SessionLocal,
-    ExecutiveRole,
+    get_db_session,
 )
 from app.src.enums import OrderIn
 from app.src.filters import IDFilter, PaginationFilter, UpdatedOnFilter, CreatedOnFilter
 from app.src.urls import URL_EXECUTIVE_ROLE_MAP
 from app.src.permissions.executive import PermissionPath
-from app.src import exceptions
+from app.src import exceptions, schemas
+from app.src.schemas import PatchForm
 from app.src.openobserve import log_event
 from app.src.validators import validate_id, verify_token, authorize_executive
 from app.src.functions import (
@@ -64,10 +67,10 @@ class CreateForm(BaseModel):
     executive_id: int = Field()
 
 
-class UpdateForm(BaseModel):
+class UpdateForm(PatchForm):
     """Form data for updating an executive role mapping."""
 
-    role_id: int = Field(default=None)
+    role_id: int | None = Field(default=None)
 
 
 # ---------------------------------------------------------------------------
@@ -95,13 +98,20 @@ class QueryParams(UpdatedOnFilter, CreatedOnFilter, IDFilter, PaginationFilter):
 # ---------------------------------------------------------------------------
 ## Core Functions
 # ---------------------------------------------------------------------------
-def create_executive_role_map(session: Session, form_param: CreateForm) -> dict:
+def create_executive_role_map(
+    session: Session,
+    form_param: CreateForm,
+    token: ExecutiveToken,
+    request_info: schemas.RequestInfo,
+) -> dict:
     """
     Creates a new executive role mapping with the provided form data.
 
     Args:
         session (Session): Active SQLAlchemy database session.
         form_param (CreateForm): Form data for creating a new executive role mapping.
+        token (ExecutiveToken): Authenticated executive token.
+        request_info (schemas.RequestInfo): Request information for logging.
 
     Returns:
         dict: Created executive role mapping data.
@@ -111,47 +121,84 @@ def create_executive_role_map(session: Session, form_param: CreateForm) -> dict:
     )
     validate_id(session, ExecutiveRole, form_param.role_id, ExecutiveRoleMap.role_id)
 
-    role_map = ExecutiveRoleMap(
+    executive_role_map = ExecutiveRoleMap(
         role_id=form_param.role_id, executive_id=form_param.executive_id
     )
-    session.add(role_map)
+    session.add(executive_role_map)
     session.commit()
-    session.refresh(role_map)
-    return jsonable_encoder(role_map)
+    session.refresh(executive_role_map)
+
+    executive_role_map_data = jsonable_encoder(executive_role_map)
+    log_event(token, request_info, executive_role_map_data)
+    return executive_role_map_data
 
 
 def update_executive_role_map(
-    session: Session, id: int, form_param: UpdateForm
-) -> tuple[bool, dict]:
+    session: Session,
+    id: int,
+    form_param: UpdateForm,
+    token: ExecutiveToken,
+    request_info: schemas.RequestInfo,
+) -> dict:
     """
     Updates an Executive role mapping with the provided form data.
 
     Args:
         session (Session): SQLAlchemy database session.
         id (int): ID of the executive role mapping to update.
-        form_param (UpdateForm): Form data containing fields to update.
+        token (ExecutiveToken): Authenticated executive token.
+        request_info (schemas.RequestInfo): Request information for logging.
 
     Returns:
-        Tuple[bool, dict]:
-            - bool: True if the executive role mapping was modified and the changes were committed.
-            - dict: JSON-encoded representation of the updated executive role mapping.
+        dict: Updated executive role mapping data.
     """
-    role_map = validate_id(session, ExecutiveRoleMap, id, ExecutiveRoleMap.id)
+    executive_role_map = validate_id(session, ExecutiveRoleMap, id, ExecutiveRoleMap.id)
 
     update_data = form_param.model_dump(exclude_unset=True)
     if "role_id" in update_data:
-        if role_map.role_id != form_param.role_id:
+        if executive_role_map.role_id != update_data["role_id"]:
             validate_id(
-                session, ExecutiveRole, form_param.role_id, ExecutiveRoleMap.role_id
+                session, ExecutiveRole, update_data["role_id"], ExecutiveRoleMap.role_id
             )
-            role_map.role_id = form_param.role_id
-            update_data.pop("role_id")
+            executive_role_map.role_id = update_data["role_id"]
+        update_data.pop("role_id")
 
-    updated = session.is_modified(role_map)
-    if updated:
+    if session.is_modified(executive_role_map):
         session.commit()
-        session.refresh(role_map)
-    return updated, jsonable_encoder(role_map)
+        session.refresh(executive_role_map)
+        executive_role_map_data = jsonable_encoder(executive_role_map)
+        log_event(token, request_info, executive_role_map_data)
+    else:
+        executive_role_map_data = jsonable_encoder(executive_role_map)
+    return executive_role_map_data
+
+
+def delete_executive_role_map(
+    session: Session,
+    id: int,
+    token: ExecutiveToken,
+    request_info: schemas.RequestInfo,
+):
+    """
+    Deletes an executive role mapping from the database.
+
+    Args:
+        session (Session): Active SQLAlchemy database session.
+        id (int): ID of the executive role mapping to delete.
+
+    Returns:
+        None
+    """
+    executive_role_map = (
+        session.query(ExecutiveRoleMap).filter(ExecutiveRoleMap.id == id).first()
+    )
+    if executive_role_map is None:
+        return
+
+    executive_role_map_data = jsonable_encoder(executive_role_map)
+    session.delete(executive_role_map)
+    session.commit()
+    log_event(token, request_info, executive_role_map_data)
 
 
 def search_executive_role_maps(
@@ -188,30 +235,8 @@ def search_executive_role_maps(
     query = query.order_by(ordering_func())
     query = query.offset(query_params.offset).limit(query_params.limit)
 
-    role_maps = query.all()
-    return role_maps
-
-
-def delete_executive_role_map(session: Session, id: int) -> tuple[bool, dict]:
-    """
-    Deletes an executive role mapping from the database.
-
-    Args:
-        session (Session): Active SQLAlchemy database session.
-        id (int): ID of the executive role mapping to delete.
-
-    Returns:
-        Tuple[bool, dict]:
-            - bool: True if the executive role mapping was found and deleted.
-            - dict: JSON-encoded representation of the deleted executive role mapping.
-    """
-    role_map = session.query(ExecutiveRoleMap).filter(ExecutiveRoleMap.id == id).first()
-    if role_map is not None:
-        role_map_data = jsonable_encoder(role_map)
-        session.delete(role_map)
-        session.commit()
-        return True, role_map_data
-    return False, {}
+    executive_role_maps = query.all()
+    return executive_role_maps
 
 
 # ---------------------------------------------------------------------------
@@ -287,20 +312,15 @@ async def create_executive_role_map_for_executive(
     form_param: CreateForm,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         token = authorize_executive(
             session, access_token, [PermissionPath.UPDATE_EXECUTIVE_ROLE]
         )
-
-        role_map_data = create_executive_role_map(session, form_param)
-        log_event(token, request_info, role_map_data)
-        return role_map_data
+        return create_executive_role_map(session, form_param, token, request_info)
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()
 
 
 @route_executive.patch(
@@ -317,21 +337,15 @@ async def update_executive_role_map_for_executive(
     form_param: UpdateForm,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         token = authorize_executive(
             session, access_token, [PermissionPath.UPDATE_EXECUTIVE_ROLE]
         )
-
-        updated, role_map_data = update_executive_role_map(session, id, form_param)
-        if updated:
-            log_event(token, request_info, role_map_data)
-        return role_map_data
+        return update_executive_role_map(session, id, form_param, token, request_info)
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()
 
 
 @route_executive.delete(
@@ -346,21 +360,16 @@ async def delete_executive_role_map_for_executive(
     id: int,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         token = authorize_executive(
             session, access_token, [PermissionPath.UPDATE_EXECUTIVE_ROLE]
         )
-
-        deleted, role_map_data = delete_executive_role_map(session, id)
-        if deleted:
-            log_event(token, request_info, role_map_data)
+        delete_executive_role_map(session, id, token, request_info)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()
 
 
 @route_executive.get(
@@ -374,13 +383,10 @@ async def delete_executive_role_map_for_executive(
 async def fetch_executive_role_maps_for_executive(
     query_params: QueryParams = Depends(),
     access_token=Depends(oauth2_executive),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
-
         return search_executive_role_maps(session, query_params)
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()

--- a/app/api/executive_role_map.py
+++ b/app/api/executive_role_map.py
@@ -146,6 +146,7 @@ def update_executive_role_map(
     Args:
         session (Session): SQLAlchemy database session.
         id (int): ID of the executive role mapping to update.
+        form_param (UpdateForm): Form data for updating the executive role mapping.
         token (ExecutiveToken): Authenticated executive token.
         request_info (schemas.RequestInfo): Request information for logging.
 
@@ -178,16 +179,15 @@ def delete_executive_role_map(
     id: int,
     token: ExecutiveToken,
     request_info: schemas.RequestInfo,
-):
+) -> None:
     """
     Deletes an executive role mapping from the database.
 
     Args:
         session (Session): Active SQLAlchemy database session.
         id (int): ID of the executive role mapping to delete.
-
-    Returns:
-        None
+        token (ExecutiveToken): Authenticated executive token.
+        request_info (schemas.RequestInfo): Request information for logging.
     """
     executive_role_map = (
         session.query(ExecutiveRoleMap).filter(ExecutiveRoleMap.id == id).first()

--- a/app/api/landmark.py
+++ b/app/api/landmark.py
@@ -333,7 +333,7 @@ def update_landmark(
 
 def delete_landmark(
     session: Session, id: int, token: ExecutiveToken, request_info: schemas.RequestInfo
-):
+) -> None:
     """
     Delete a landmark from the database.
 


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
This change introduces executive role mapping management so authorized executives can link executives to roles through the API, with validation and permission checks applied to each operation.

Reason for the change?

- To enable secure management of executive-to-role assignments through the API and ensure role mappings are validated before being created or updated.
 
What changed?

-  Added CRUD endpoints for executive role mappings
- Introduced create, update, fetch, and delete handlers for role mappings
- Added request validation for role and executive IDs
- Enforced executive authorization for role mapping changes
- Added filtering and pagination support for fetching mappings

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Authenticate as an executive user with the required permissions
- Verify that:
     -  valid role and executive IDs create/update successfully
     -  mappings can be fetched with filters
     - unauthorized or invalid requests return the expected errors


### **Checklist (Self-Review)**
- [ ] I have tested the changes locally or in a staging environment.
- [ ] I have reviewed my own code for potential issues.
- [ ] I have applied code formatting/linting.
- [ ] I have added or updated tests as needed.
- [ ] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
N/A


### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->

