### PR TITLE
F385/code refactoring 08

### DIFF
--- a/app/api/duty.py
+++ b/app/api/duty.py
@@ -18,7 +18,6 @@ from sqlalchemy import func
 
 from app.api.bearer import bearer_operator, oauth2_executive
 from app.src.db import (
-    SessionLocal,
     OperatorToken,
     Duty,
     ExecutiveToken,

--- a/app/api/duty.py
+++ b/app/api/duty.py
@@ -1,14 +1,15 @@
 """
-Duty API Router for EnteBus.
+Duty API router.
 
-Provides endpoints for managing duties, including update and retrieval.
-Uses Pydantic schemas for input validation and structured output.
+Provides endpoints for managing duties:
+    - PATCH (operator, executive)
+    - GET (operator, executive)
 """
 
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import StrEnum
-from typing import List
+from typing import Union
 from fastapi import APIRouter, Depends, Query, status
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
@@ -23,6 +24,7 @@ from app.src.db import (
     ExecutiveToken,
     Service,
     PaperTicket,
+    get_db_session,
 )
 from app.src.enums import DutyStatus, ServiceStatus
 from app.src.urls import URL_DUTY
@@ -47,7 +49,7 @@ from app.src.functions import (
     get_request_info,
 )
 from app.src.redis import acquire_lock, release_lock
-from app.src import exceptions
+from app.src import exceptions, schemas
 from app.src.enums import OrderIn
 from app.src.filters import CreatedOnFilter, IDFilter, PaginationFilter, UpdatedOnFilter
 from app.api.service import construct_service_transition_lock
@@ -80,7 +82,7 @@ class DutySchema(BaseModel):
 class UpdateForm(BaseModel):
     """Form data for updating a duty."""
 
-    status: DutyStatus = Field(description=enum_str(DutyStatus), default=None)
+    status: DutyStatus | None = Field(description=enum_str(DutyStatus), default=None)
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +101,7 @@ class QueryParamsForOP(PaginationFilter, IDFilter, CreatedOnFilter, UpdatedOnFil
 
     service_id: int | None = Field(Query(default=None))
     operator_id: int | None = Field(Query(default=None))
-    status_list: List[DutyStatus] | None = Field(
+    status_list: list[DutyStatus] | None = Field(
         Query(default=None, description=enum_str(DutyStatus))
     )
     order_by: OrderBy = Field(Query(default=OrderBy.ID, description=enum_str(OrderBy)))
@@ -124,8 +126,13 @@ class QueryParams(QueryParamsForEX):
 ## Core Functions
 # ---------------------------------------------------------------------------
 def update_duty(
-    session: Session, id: int, form_param: UpdateForm, duty_filter=None
-) -> tuple[bool, dict]:
+    session: Session,
+    id: int,
+    form_param: UpdateForm,
+    token: Union[ExecutiveToken, OperatorToken],
+    request_info: schemas.RequestInfo,
+    duty_filter=None,
+) -> dict:
     """
     Updates a duty record based on the requested status transition.
 
@@ -137,12 +144,12 @@ def update_duty(
         session (Session): SQLAlchemy database session.
         id (int): ID of the duty to update.
         form_param (UpdateForm): Form data containing new status.
+        token (Union[ExecutiveToken, OperatorToken]): Authenticated token.
+        request_info (schemas.RequestInfo): Request information for logging.
         duty_filter (Optional): Additional filter for duty validation.
 
     Returns:
-        Tuple[bool, dict]:
-            - bool: True if the duty was modified and the changes were committed.
-            - dict: JSON-encoded representation of the updated duty.
+        dict: A dictionary containing the updated duty data.
     """
     service_lock = None
     try:
@@ -158,15 +165,16 @@ def update_duty(
         update_data = form_param.model_dump(exclude_unset=True)
         service = None
         if "status" in update_data:
-            if form_param.status != duty.status:
+            if update_data["status"] != duty.status:
                 validate_state_transition(
                     allowed_duty_status_transitions,
                     duty.status,
-                    form_param.status,
+                    update_data["status"],
                     Duty.status,
                 )
+
                 # Handle status transitions
-                if form_param.status == DutyStatus.ENDED:
+                if update_data["status"] == DutyStatus.ENDED:
                     duty.collection = (
                         session.query(func.sum(PaperTicket.amount))
                         .filter(PaperTicket.duty_id == duty.id)
@@ -174,32 +182,33 @@ def update_duty(
                     )
                     utc_now = datetime.now(timezone.utc)
                     duty.finished_on = utc_now
-                elif form_param.status == DutyStatus.STARTED:
+                elif update_data["status"] == DutyStatus.STARTED:
                     duty.finished_on = None
-                    duty.collection = 0
+                    duty.collection = Decimal(0)
                     service = (
                         session.query(Service)
                         .filter(Service.id == duty.service_id)
                         .first()
                     )
+                    assert service is not None, "Service cannot be None."
                     if service.status == ServiceStatus.ENDED:
                         service.status = ServiceStatus.STARTED
-                duty.status = form_param.status
-                update_data.pop("status")
+                duty.status = update_data["status"]
+            update_data.pop("status")
 
-        updated = session.is_modified(duty) or (
-            service and session.is_modified(service)
-        )
-        if updated:
+        if session.is_modified(duty) or (service and session.is_modified(service)):
             session.commit()
             session.refresh(duty)
-        duty_data = jsonable_encoder(duty)
-        return updated, duty_data
+            duty_data = jsonable_encoder(duty)
+            log_event(token, request_info, duty_data)
+        else:
+            duty_data = jsonable_encoder(duty)
+        return duty_data
     finally:
         release_lock(service_lock)
 
 
-def search_duties(session: Session, query_params: QueryParams) -> List[Duty]:
+def search_duties(session: Session, query_params: QueryParams) -> list[Duty]:
     """
     Search for Duties based on provided query parameters.
 
@@ -211,7 +220,7 @@ def search_duties(session: Session, query_params: QueryParams) -> List[Duty]:
         query_params (QueryParams): Query parameters containing search criteria.
 
     Returns:
-        List[Duty]: List of Duties that match the search criteria.
+        list[Duty]: List of Duties that match the search criteria.
     """
     query = session.query(Duty)
 
@@ -298,48 +307,43 @@ async def update_duty_for_executive(
     form_param: UpdateForm,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         token = authorize_executive(
             session,
             access_token,
             [ExecutivePermissionPath.UPDATE_COMPANY_SERVICE_DUTY],
         )
-
-        updated, duty_data = update_duty(
-            session, id, UpdateForm(**form_param.model_dump(exclude_unset=True))
+        return update_duty(
+            session,
+            id,
+            UpdateForm(**form_param.model_dump(exclude_unset=True)),
+            token,
+            request_info,
         )
-        if updated:
-            log_event(token, request_info, duty_data)
-        return duty_data
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()
 
 
 @route_executive.get(
     URL_DUTY,
     summary="Fetch duty",
     tags=["Duty"],
-    response_model=List[DutySchema],
+    response_model=list[DutySchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=(GET_DESCRIPTION.to_string()),
 )
 async def fetch_duties_for_executive(
     query_params: QueryParamsForEX = Depends(),
     access_token=Depends(oauth2_executive),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         verify_token(session, ExecutiveToken, access_token)
-
         return search_duties(session, QueryParams(**query_params.model_dump()))
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()
 
 
 # ---------------------------------------------------------------------------
@@ -365,51 +369,44 @@ async def update_duty_for_operator(
     form_param: UpdateForm,
     access_token=Depends(bearer_operator),
     request_info=Depends(get_request_info),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         token = authorize_operator(
             session,
             access_token.credentials,
             [OperatorPermissionPath.UPDATE_COMPANY_SERVICE_DUTY],
         )
-
-        updated, duty_data = update_duty(
+        return update_duty(
             session,
             id,
             UpdateForm(**form_param.model_dump(exclude_unset=True)),
+            token,
+            request_info,
             duty_filter=(Duty.company_id == token.company_id),
         )
-        if updated:
-            log_event(token, request_info, duty_data)
-        return duty_data
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()
 
 
 @route_operator.get(
     URL_DUTY,
     summary="Fetch duty",
     tags=["Duty"],
-    response_model=List[DutySchema],
+    response_model=list[DutySchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=(GET_DESCRIPTION.to_string()),
 )
 async def fetch_duties_for_operator(
     query_params: QueryParamsForOP = Depends(),
     access_token=Depends(bearer_operator),
+    session: Session = Depends(get_db_session),
 ):
     try:
-        session = SessionLocal()
         token = verify_token(session, OperatorToken, access_token.credentials)
-
         query_params = QueryParams(
             **query_params.model_dump(), company_id=token.company_id
         )
         return search_duties(session, query_params)
     except Exception as e:
         exceptions.handle(e)
-    finally:
-        session.close()

--- a/app/api/executive_image.py
+++ b/app/api/executive_image.py
@@ -298,7 +298,6 @@ GET_EXCEPTIONS = [
 FETCH_EXCEPTIONS = [
     exceptions.InvalidToken(),
     exceptions.UnknownValue(ExecutiveImage.id),
-    exceptions.FileNotFound(),
 ]
 
 

--- a/app/src/types.py
+++ b/app/src/types.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import TypeVar
 from pydantic import BaseModel
 from shapely.geometry.base import BaseGeometry
@@ -11,3 +12,4 @@ TokenT = TypeVar("TokenT", ExecutiveToken, OperatorToken, VendorToken)
 BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
 ORMbaseT = TypeVar("ORMbaseT", bound=ORMbase)
 GeometryT = TypeVar("GeometryT", bound=BaseGeometry)
+EnumT = TypeVar("EnumT", bound=Enum)

--- a/app/src/validators.py
+++ b/app/src/validators.py
@@ -6,8 +6,8 @@ making it easier for developers to integrate them into their projects.
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, List, Sequence, Type, Union
-from dns.enum import IntEnum
+from enum import IntEnum
+from typing import Any, List, Mapping, Sequence, Type, Union
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.orm.session import Session
@@ -53,6 +53,7 @@ from app.src.constants import (
 )
 from app.src.dynamic_fare.v1 import DynamicFare
 from app.src.types import GeometryT, ORMbaseT, TokenT
+from app.src.types import EnumT
 
 
 def user_credentials(
@@ -473,13 +474,13 @@ def validate_AABB(polygon: Polygon) -> bool:
 
 
 def is_valid_transition(
-    transitions: dict[Any, list[Any]], old_state: Any, new_state: Any
+    transitions: Mapping[EnumT, Sequence[EnumT]], old_state: Any, new_state: Any
 ) -> bool:
     """
     Check if a state transition is valid.
 
     Args:
-        transitions (dict[Any, list[Any]]): A mapping of valid state transitions.
+        transitions (Mapping[EnumT, Sequence[EnumT]]): A mapping of valid state transitions.
         old_state (Any): The current state before the transition.
         new_state (Any): The desired state after the transition.
 
@@ -637,7 +638,7 @@ def validate_fare_function(function: str, attributes: dict) -> DynamicFare:
 
 
 def validate_state_transition(
-    transitions: dict[IntEnum, list[IntEnum]],
+    transitions: Mapping[EnumT, Sequence[EnumT]],
     old_state: IntEnum,
     new_state: IntEnum,
     column: InstrumentedAttribute,
@@ -646,7 +647,7 @@ def validate_state_transition(
     Validate whether a state transition is allowed.
 
     Args:
-        transitions (dict[IntEnum, list[IntEnum]]): A mapping of valid state transitions.
+        transitions (Mapping[EnumT, Sequence[EnumT]]): A mapping of valid state transitions.
         old_state (IntEnum): The current state before the transition.
         new_state (IntEnum): The desired state after the transition.
         column (InstrumentedAttribute): The ORM column associated with the state, used for exception messages.


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->

Refactors the duty API and related helper code to improve clarity, maintainability, and type safety while preserving the existing business behavior.

Reason for the change?

- The duty API and its supporting utilities were refactored to improve maintainability, readability, and type safety. The change also reduces manual session handling and makes the endpoint logic more consistent for executive and operator flows.

What changed?
 
- Updated duty.py to streamline duty update and fetch handling, improve endpoint documentation, and use dependency-injected database sessions.
- Added clearer shared typing support in types.py for tokens, ORM models, geometry objects, and enums.
- Refined validator-related signatures and annotations in validators.py to make the code easier to follow and safer to extend.

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Verify the duty endpoints for both executive and operator roles.
- Exercise the duty update flow for:
            - STARTED → ENDED to confirm collection and finish-time handling
            - ENDED → STARTED to confirm the duty is reactivated correctly
- Confirm that permission checks and access restrictions still work as expected.
- Run the relevant API or regression tests if available.


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [ ] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
N/A


### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
