### PR TITLE
Add waypoint type to landmark in route model and forms

### DIFF
--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -25,7 +25,7 @@ from app.src.db import (
     VendorToken,
     get_db_session,
 )
-from app.src.enums import OrderIn
+from app.src.enums import OrderIn, WaypointType
 from app.src.urls import URL_LANDMARK_IN_ROUTE
 from app.src.validators import (
     validate_id,
@@ -35,6 +35,7 @@ from app.src.validators import (
     authorize_operator,
 )
 from app.src.functions import (
+    apply_type_filters,
     enum_str,
     fuse_exception_responses,
     get_by_id,
@@ -91,6 +92,9 @@ class CreateForm(BaseModel):
 
     route_id: int = Field()
     landmark_id: int = Field()
+    type: WaypointType = Field(
+        description=enum_str(WaypointType), default=WaypointType.MAIN_STOP
+    )
     distance_from_start: int = Field(gt=-1)
     arrival_delta: int = Field(gt=-1)
     departure_delta: int = Field(gt=-1)
@@ -99,6 +103,7 @@ class CreateForm(BaseModel):
 class UpdateForm(PatchForm):
     """Form data for updating an landmark in route."""
 
+    type: WaypointType | None = Field(default=None, description=enum_str(WaypointType))
     distance_from_start: int | None = Field(default=None, gt=-1)
     arrival_delta: int | None = Field(default=None, gt=-1)
     departure_delta: int | None = Field(default=None, gt=-1)
@@ -121,6 +126,9 @@ class QueryParamsForPU(IDFilter, CreatedOnFilter, UpdatedOnFilter, PaginationFil
 
     route_id: int | None = Field(Query(default=None))
     landmark_id: int | None = Field(Query(default=None))
+    type_list: list[WaypointType] | None = Field(
+        Query(default=None, description=enum_str(WaypointType))
+    )
     distance_from_start_ge: int | None = Field(Query(default=None))
     distance_from_start_le: int | None = Field(Query(default=None))
     arrival_delta_ge: int | None = Field(Query(default=None))
@@ -229,6 +237,7 @@ def create_landmark_in_route(
             company_id=route.company_id,
             route_id=form_param.route_id,
             landmark_id=form_param.landmark_id,
+            type=form_param.type,
             distance_from_start=form_param.distance_from_start,
             arrival_delta=form_param.arrival_delta,
             departure_delta=form_param.departure_delta,
@@ -428,6 +437,7 @@ def search_landmarks_in_route(
     query = apply_id_filters(query, LandmarkInRoute, query_params)
     query = apply_created_on_filters(query, LandmarkInRoute, query_params)
     query = apply_updated_on_filters(query, LandmarkInRoute, query_params)
+    query = apply_type_filters(query, LandmarkInRoute, query_params)
 
     # Ordering and pagination
     ordering_attr = getattr(LandmarkInRoute, query_params.order_by.value)

--- a/app/api/landmark_in_route.py
+++ b/app/api/landmark_in_route.py
@@ -77,6 +77,7 @@ class LandmarkInRouteSchema(BaseModel):
     company_id: int
     route_id: int
     landmark_id: int
+    type: int
     distance_from_start: int
     arrival_delta: int
     departure_delta: int

--- a/app/src/db.py
+++ b/app/src/db.py
@@ -76,6 +76,7 @@ from app.src.enums import (
     DutyStatus,
     JobType,
     TriggeringMode,
+    WaypointType,
 )
 
 
@@ -2167,6 +2168,9 @@ class LandmarkInRoute(ORMbase):
             Foreign key referencing `landmark.id` that this landmark is part of.
             Landmark referenced here cannot be deleted.
 
+        type (Integer, not null, default=WaypointType.MAIN_STOP):
+            Type of the waypoint within the route. Mapped from the `WaypointType` enum.
+
         distance_from_start (Integer, not null):
             Distance in meters from the starting landmark of the route.
             Used to determine ordering and physical spacing.
@@ -2205,6 +2209,9 @@ class LandmarkInRoute(ORMbase):
     )
     landmark_id: Mapped[int] = orm.mapped_column(
         BigInteger, ForeignKey("landmark.id"), nullable=False, index=True
+    )
+    type: Mapped[WaypointType] = orm.mapped_column(
+        Integer, nullable=False, default=WaypointType.MAIN_STOP
     )
     distance_from_start: Mapped[int] = orm.mapped_column(Integer, nullable=False)
     arrival_delta: Mapped[int] = orm.mapped_column(Integer, nullable=False)

--- a/app/src/enums.py
+++ b/app/src/enums.py
@@ -212,3 +212,11 @@ class JobType(IntEnum):
 
     SERVICE_CREATION = 1
     STATEMENT_CREATION = 2
+
+
+class WaypointType(IntEnum):
+    """Types of landmark within a route."""
+
+    MAIN_STOP = 1
+    INTERMEDIATE_STOP = 2
+    TEMPORARY_STOP = 3

--- a/tests/inputs.py
+++ b/tests/inputs.py
@@ -9,7 +9,13 @@ import numpy as np
 from shapely import wkt
 
 from app.src.constants import TMZ_PRIMARY
-from app.src.enums import BusinessType, GenderType, GrantType, PlatformType
+from app.src.enums import (
+    BusinessType,
+    GenderType,
+    GrantType,
+    PlatformType,
+    WaypointType,
+)
 from app.src.enums import (
     LandmarkType,
     CompanyStatus,
@@ -215,6 +221,7 @@ def generate_landmark_in_route_payload(
     return {
         "route_id": route_id,
         "landmark_id": landmark_id,
+        "type": WaypointType.MAIN_STOP.value,
         "distance_from_start": distance_from_start,
         "arrival_delta": arrival_delta,
         "departure_delta": departure_delta,


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
Added explicit waypoint type support for landmark-in-route records so routes can distinguish between different stop categories such as main stops, intermediate stops, and temporary stops. The change covers the database model, API request/response schemas, and query filtering.

Reason for the change?
- The existing landmark-in-route flow did not support capturing the semantic type of a route location. This made it harder to represent and query different kinds of stops accurately in route definitions and downstream route-related logic.

What changed? 
- Added a new waypoint type field to the landmark-in-route model in db.py
- Introduced and used the WaypointType enum values in enums.py
- Updated the API contract in landmark_in_route.py to:
              - accept type in create/update payloads
              - return type in API responses
              - support filtering by type through query parameters

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Verify that creating and updating a landmark-in-route record accepts a valid type value
- Verify that the API response includes the saved type
- Verify that GET requests can filter results by type using values such as MAIN_STOP INTERMEDIATE_STOP TEMPORARY_STOP

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->


### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
