### PR TITLE
Refactor bus stop endpoints to station terminology

### DIFF
--- a/app/api/controller.py
+++ b/app/api/controller.py
@@ -10,7 +10,6 @@ from fastapi import FastAPI
 
 from app.api import (
     business,
-    bus_stop,
     company,
     duty,
     executive_account,
@@ -32,6 +31,7 @@ from app.api import (
     service_automation,
     service_assignment,
     service_assignment_automation,
+    station,
     trace,
     vehicle,
     vehicle_image,
@@ -70,7 +70,7 @@ app_executive.include_router(executive_role_map.route_executive)
 app_executive.include_router(executive_account.route_executive)
 app_executive.include_router(executive_image.route_executive)
 app_executive.include_router(landmark.route_executive)
-app_executive.include_router(bus_stop.route_executive)
+app_executive.include_router(station.route_executive)
 app_executive.include_router(operator_token.route_executive)
 app_executive.include_router(company.route_executive)
 app_executive.include_router(business.route_executive)
@@ -110,7 +110,7 @@ app_vendor.include_router(vendor_role_map.route_vendor)
 app_vendor.include_router(vendor_image.route_vendor)
 app_vendor.include_router(business.route_vendor)
 app_vendor.include_router(landmark.route_vendor)
-app_vendor.include_router(bus_stop.route_vendor)
+app_vendor.include_router(station.route_vendor)
 app_vendor.include_router(vehicle.route_vendor)
 app_vendor.include_router(route.route_vendor)
 app_vendor.include_router(landmark_in_route.route_vendor)
@@ -124,7 +124,7 @@ app_vendor.include_router(service.route_vendor)
 # ------------------------------------------------------
 app_operator.include_router(operator_token.route_operator)
 app_operator.include_router(landmark.route_operator)
-app_operator.include_router(bus_stop.route_operator)
+app_operator.include_router(station.route_operator)
 app_operator.include_router(company.route_operator)
 app_operator.include_router(operator_account.route_operator)
 app_operator.include_router(operator_role.route_operator)
@@ -151,7 +151,7 @@ app_operator.include_router(job.route_operator)
 # Public routers
 # ------------------------------------------------------
 app_public.include_router(landmark.route_public)
-app_public.include_router(bus_stop.route_public)
+app_public.include_router(station.route_public)
 app_public.include_router(company.route_public)
 app_public.include_router(business.route_public)
 app_public.include_router(vehicle.route_public)

--- a/app/api/landmark.py
+++ b/app/api/landmark.py
@@ -30,7 +30,7 @@ from app.src.constants import (
     MIN_LANDMARK_AREA,
 )
 from app.src.db import (
-    BusStop,
+    Station,
     Landmark,
     ExecutiveToken,
     VendorToken,
@@ -312,11 +312,11 @@ def update_landmark(
             if distance_in_meters > MAX_LANDMARK_UPDATE_DISTANCE:
                 raise exceptions.LandmarkDistanceLimitExceeded()
 
-            bus_stops = session.query(BusStop).filter(BusStop.landmark_id == id).all()
-            for bus_stop in bus_stops:
-                bus_stop_geom = load_geometry(bus_stop.location)
-                if not bus_stop_geom.within(new_boundary_geom):
-                    raise exceptions.BusStopOutsideLandmark()
+            stations = session.query(Station).filter(Station.landmark_id == id).all()
+            for station in stations:
+                station_geom = load_geometry(station.location)
+                if not station_geom.within(new_boundary_geom):
+                    raise exceptions.StationOutsideLandmark()
             landmark.boundary = to_WKB(new_boundary_geom)
         update_data.pop("boundary")
 
@@ -443,7 +443,7 @@ PATCH_EXCEPTIONS = [
     exceptions.InvalidSRID4326(),
     exceptions.InvalidAABB(),
     exceptions.InvalidBoundaryArea(),
-    exceptions.BusStopOutsideLandmark(),
+    exceptions.StationOutsideLandmark(),
     exceptions.OverlappingLandmarkBoundary(),
     exceptions.LandmarkDistanceLimitExceeded(),
 ]
@@ -484,7 +484,7 @@ PATCH_DESCRIPTION = (
         f"When updating the boundary, the new centroid cannot be more than {MAX_LANDMARK_UPDATE_DISTANCE / 1000} km from the original centroid."
     )
     .add_line(
-        "All bus stops associated with the landmark must remain within the updated boundary."
+        "All stations associated with the landmark must remain within the updated boundary."
     )
     .add_line("Logged-in executive must have the `landmark.update` permission.")
 )

--- a/app/api/station.py
+++ b/app/api/station.py
@@ -1,7 +1,7 @@
 """
-Bus Stop API router.
+Station API router.
 
-Provides endpoints for managing bus stops:
+Provides endpoints for managing stations:
     - POST (executive)
     - PATCH (executive)
     - DELETE (executive)
@@ -21,7 +21,7 @@ from sqlalchemy import String, func, or_
 
 from app.api.bearer import oauth2_executive, bearer_operator, bearer_vendor
 from app.src.db import (
-    BusStop,
+    Station,
     ExecutiveToken,
     Landmark,
     OperatorToken,
@@ -40,10 +40,10 @@ from app.src.permissions.executive import PermissionPath
 from app.src import exceptions, schemas
 from app.src.schemas import PatchForm
 from app.src.regex import NAME_PATTERN
-from app.src.urls import URL_BUS_STOP
+from app.src.urls import URL_STATION
 from app.src.openobserve import log_event
 from app.src.description import Description
-from app.src.constants import MAX_BUS_STOPS_PER_LANDMARK
+from app.src.constants import MAX_STATIONS_PER_LANDMARK
 from app.src.validators import (
     verify_token,
     validate_id,
@@ -74,8 +74,8 @@ route_public = APIRouter()
 # ---------------------------------------------------------------------------
 ## Output Schema
 # ---------------------------------------------------------------------------
-class BusStopSchema(BaseModel):
-    """Schema for bus stop response."""
+class StationSchema(BaseModel):
+    """Schema for station response."""
 
     id: int
     name: str
@@ -89,7 +89,7 @@ class BusStopSchema(BaseModel):
 ## Input Forms
 # ---------------------------------------------------------------------------
 class CreateForm(BaseModel):
-    """Form data for creating a new bus stop."""
+    """Form data for creating a new station."""
 
     name: str = Field(min_length=1, max_length=32, pattern=NAME_PATTERN)
     landmark_id: int = Field()
@@ -102,7 +102,7 @@ class CreateForm(BaseModel):
 
 
 class UpdateForm(PatchForm):
-    """Form data for updating a bus stop."""
+    """Form data for updating a station."""
 
     name: str | None = Field(
         min_length=1, max_length=32, pattern=NAME_PATTERN, default=None
@@ -134,7 +134,7 @@ class QueryParams(
     IDFilter,
     PaginationFilter,
 ):
-    """Query parameters for fetching bus stops."""
+    """Query parameters for fetching stations."""
 
     search: str | None = Field(Query(default=None))
     location: str | None = Field(
@@ -157,7 +157,7 @@ class QueryParams(
 # ---------------------------------------------------------------------------
 def validate_location(session: Session, location_wkt: str, landmark_id: int) -> Point:
     """
-    Validate a bus stop location geometry. This function takes a WKT string representing a point
+    Validate a station location geometry. This function takes a WKT string representing a point
     and validates it against the landmark boundary.
 
     Args:
@@ -170,84 +170,84 @@ def validate_location(session: Session, location_wkt: str, landmark_id: int) -> 
 
     Raises:
         UnknownValue: If the landmark doesn't exist.
-        BusStopOutsideLandmark: If the location is outside the landmark boundary.
+        StationOutsideLandmark: If the location is outside the landmark boundary.
     """
     # Validate WKT and SRID
     location_geom = validate_wkt_string(location_wkt, Point)
     validate_srid_4326(location_geom)
 
     # Validate if the location is within landmark boundary
-    landmark = validate_id(session, Landmark, landmark_id, BusStop.landmark_id)
+    landmark = validate_id(session, Landmark, landmark_id, Station.landmark_id)
 
     boundary_geom = load_geometry(landmark.boundary)
     if not boundary_geom.contains(location_geom):
-        raise exceptions.BusStopOutsideLandmark()
+        raise exceptions.StationOutsideLandmark()
     return location_geom
 
 
-def bus_stop_to_dict(bus_stop: BusStop) -> dict:
+def station_to_dict(station: Station) -> dict:
     """
-    Convert a BusStop object to a dictionary representation.
+    Convert a Station object to a dictionary representation.
 
     Args:
-        bus_stop (BusStop): The BusStop object to convert.
+        station (Station): The Station object to convert.
 
     Returns:
-        dict: A dictionary representation of the BusStop object.
+        dict: A dictionary representation of the Station object.
     """
-    bus_stop_data = jsonable_encoder(bus_stop, exclude={BusStop.location.name})
-    bus_stop_data[BusStop.location.name] = (load_geometry(bus_stop.location)).wkt
-    return bus_stop_data
+    station_data = jsonable_encoder(station, exclude={Station.location.name})
+    station_data[Station.location.name] = (load_geometry(station.location)).wkt
+    return station_data
 
 
 # ---------------------------------------------------------------------------
 ## Core Functions
 # ---------------------------------------------------------------------------
-def create_bus_stop(
+def create_station(
     session: Session,
     form_param: CreateForm,
     token: ExecutiveToken,
     request_info: schemas.RequestInfo,
 ) -> dict:
     """
-    Create a new bus stop in the database.
+    Create a new station in the database.
 
     Args:
         session (Session): Active SQLAlchemy database session.
-        form_param (CreateForm): Form data for creating a new bus stop.
+        form_param (CreateForm): Form data for creating a new station.
         token (ExecutiveToken): Authenticated executive token.
         request_info (schemas.RequestInfo): Request information for logging.
 
     Returns:
-        dict: Created bus stop data with location in WKT format.
+        dict: Created station data with location in WKT format.
     """
-    bus_stop_count = (
-        session.query(BusStop)
-        .filter(BusStop.landmark_id == form_param.landmark_id)
+    station_count = (
+        session.query(Station)
+        .filter(Station.landmark_id == form_param.landmark_id)
         .count()
     )
-    if bus_stop_count >= MAX_BUS_STOPS_PER_LANDMARK:
-        raise exceptions.LimitExceeded(BusStop)
+    if station_count >= MAX_STATIONS_PER_LANDMARK:
+        raise exceptions.LimitExceeded(Station)
 
     # Validate location (WKT, SRID, and landmark boundary)
     location_geom = validate_location(
         session, form_param.location, form_param.landmark_id
     )
-    bus_stop = BusStop(
+    station = Station(
         name=form_param.name,
         landmark_id=form_param.landmark_id,
         location=to_WKB(location_geom),
     )
-    session.add(bus_stop)
+    session.add(station)
     session.commit()
-    session.refresh(bus_stop)
+    session.refresh(station)
 
-    bus_stop_data = bus_stop_to_dict(bus_stop)
-    log_event(token, request_info, bus_stop_data)
-    return bus_stop_data
+    station_data = station_to_dict(station)
+    log_event(token, request_info, station_data)
+    return station_data
 
 
-def update_bus_stop(
+def update_station(
     session: Session,
     id: int,
     form_param: UpdateForm,
@@ -255,110 +255,110 @@ def update_bus_stop(
     request_info: schemas.RequestInfo,
 ) -> dict:
     """
-    Update an existing bus stop in the database.
+    Update an existing station in the database.
 
     Args:
         session (Session): Active SQLAlchemy database session.
-        id (int): ID of the bus stop to update.
-        form_param (UpdateForm): Form data for updating the bus stop.
+        id (int): ID of the station to update.
+        form_param (UpdateForm): Form data for updating the station.
         token (ExecutiveToken): Authenticated executive token.
         request_info (schemas.RequestInfo): Request information for logging.
 
     Returns:
-        dict: Updated bus stop data with location in WKT format.
+        dict: Updated station data with location in WKT format.
     """
-    bus_stop = validate_id(session, BusStop, id, BusStop.id)
+    station = validate_id(session, Station, id, Station.id)
 
     update_data = form_param.model_dump(exclude_unset=True)
     if "location" in update_data:
-        old_location_geom = load_geometry(bus_stop.location)
+        old_location_geom = load_geometry(station.location)
         new_location_geom = validate_location(
-            session, update_data["location"], bus_stop.landmark_id
+            session, update_data["location"], station.landmark_id
         )
         if not new_location_geom.equals(old_location_geom):
-            bus_stop.location = to_WKB(new_location_geom)
+            station.location = to_WKB(new_location_geom)
         update_data.pop("location")
 
-    update_if_changed(bus_stop, update_data)
-    if session.is_modified(bus_stop):
+    update_if_changed(station, update_data)
+    if session.is_modified(station):
         session.commit()
-        session.refresh(bus_stop)
-        bus_stop_data = bus_stop_to_dict(bus_stop)
-        log_event(token, request_info, bus_stop_data)
+        session.refresh(station)
+        station_data = station_to_dict(station)
+        log_event(token, request_info, station_data)
     else:
-        bus_stop_data = bus_stop_to_dict(bus_stop)
-    return bus_stop_data
+        station_data = station_to_dict(station)
+    return station_data
 
 
-def delete_bus_stop(
+def delete_station(
     session: Session, id: int, token: ExecutiveToken, request_info: schemas.RequestInfo
 ) -> None:
     """
-    Delete a bus stop from the database.
+    Delete a station from the database.
 
     Args:
         session (Session): Active SQLAlchemy database session.
-        id (int): ID of the bus stop to delete.
+        id (int): ID of the station to delete.
         token (ExecutiveToken): Authenticated executive token.
         request_info (schemas.RequestInfo): Request information for logging.
     """
-    bus_stop = get_by_id(session, BusStop, id)
-    if bus_stop is None:
+    station = get_by_id(session, Station, id)
+    if station is None:
         return
 
-    bus_stop_data = bus_stop_to_dict(bus_stop)
-    session.delete(bus_stop)
+    station_data = station_to_dict(station)
+    session.delete(station)
     session.commit()
-    log_event(token, request_info, bus_stop_data)
+    log_event(token, request_info, station_data)
 
 
-def search_bus_stops(session: Session, query_params: QueryParams) -> list[BusStop]:
+def search_stations(session: Session, query_params: QueryParams) -> list[Station]:
     """
-    Search for bus stops based on provided query parameters.
+    Search for stations based on provided query parameters.
 
     This function supports multiple filtering, searching, ordering, and
-    pagination capabilities to retrieve bus stops that match various criteria.
+    pagination capabilities to retrieve stations that match various criteria.
 
     Args:
         session (Session): Active SQLAlchemy database session.
         query_params (QueryParams): Query parameters containing search criteria.
 
     Returns:
-        list[BusStop]: List of bus stops that match the search criteria.
+        list[Station]: List of stations that match the search criteria.
     """
-    query = session.query(BusStop)
+    query = session.query(Station)
     validated_location = None
     if query_params.location is not None:
         geometry = validate_wkt_string(query_params.location, Point)
         validate_srid_4326(geometry)
         validated_location = wkt.dumps(geometry)
     if query_params.landmark_id_list is not None:
-        query = query.filter(BusStop.landmark_id.in_(query_params.landmark_id_list))
+        query = query.filter(Station.landmark_id.in_(query_params.landmark_id_list))
 
     # Common search
     if query_params.search:
         search = f"%{query_params.search}%"
         query = query.filter(
-            or_(BusStop.id.cast(String).ilike(search), BusStop.name.ilike(search))
+            or_(Station.id.cast(String).ilike(search), Station.name.ilike(search))
         )
 
     # Generalized filters
-    query = apply_id_filters(query, BusStop, query_params)
-    query = apply_created_on_filters(query, BusStop, query_params)
-    query = apply_updated_on_filters(query, BusStop, query_params)
-    query = apply_name_filters(query, BusStop, query_params)
+    query = apply_id_filters(query, Station, query_params)
+    query = apply_created_on_filters(query, Station, query_params)
+    query = apply_updated_on_filters(query, Station, query_params)
+    query = apply_name_filters(query, Station, query_params)
 
     # Ordering and pagination
     if query_params.order_by == OrderBy.LOCATION:
         if validated_location is not None:
             ordering_attr = func.ST_Distance(
-                BusStop.location.cast(Geography),
+                Station.location.cast(Geography),
                 func.ST_GeogFromText(validated_location),
             )
         else:
-            ordering_attr = BusStop.id
+            ordering_attr = Station.id
     else:
-        ordering_attr = getattr(BusStop, query_params.order_by.value)
+        ordering_attr = getattr(Station, query_params.order_by.value)
     ordering_func = (
         ordering_attr.asc
         if query_params.order_in == OrderIn.ASCENDING
@@ -367,8 +367,8 @@ def search_bus_stops(session: Session, query_params: QueryParams) -> list[BusSto
     query = query.order_by(ordering_func())
     query = query.offset(query_params.offset).limit(query_params.limit)
 
-    bus_stops = query.all()
-    return bus_stops
+    stations = query.all()
+    return stations
 
 
 # ---------------------------------------------------------------------------
@@ -379,18 +379,18 @@ POST_EXCEPTIONS = [
     exceptions.NoPermission(),
     exceptions.InvalidWKTStringOrType(),
     exceptions.InvalidSRID4326(),
-    exceptions.UnknownValue(BusStop.landmark_id),
-    exceptions.BusStopOutsideLandmark(),
-    exceptions.LimitExceeded(BusStop),
+    exceptions.UnknownValue(Station.landmark_id),
+    exceptions.StationOutsideLandmark(),
+    exceptions.LimitExceeded(Station),
 ]
 
 PATCH_EXCEPTIONS = [
     exceptions.InvalidToken(),
     exceptions.NoPermission(),
-    exceptions.UnknownValue(BusStop.id),
+    exceptions.UnknownValue(Station.id),
     exceptions.InvalidWKTStringOrType(),
     exceptions.InvalidSRID4326(),
-    exceptions.BusStopOutsideLandmark(),
+    exceptions.StationOutsideLandmark(),
 ]
 
 DELETE_EXCEPTIONS = [
@@ -410,37 +410,37 @@ GET_EXCEPTIONS = [
 # ---------------------------------------------------------------------------
 POST_DESCRIPTION = (
     Description()
-    .add_head("Creates a new bus stop.")
+    .add_head("Creates a new station.")
     .add_line("The location field must be a valid WKT string.")
     .add_line("The coordinates must be in longitude/latitude format.")
     .add_line("Use WGS84 compatible coordinates within SRID 4326 bounds.")
     .add_line("The location must be within the boundary of the landmark.")
-    .add_line("Logged-in executive must have `landmark.bus_stop.create` permission.")
+    .add_line("Logged-in executive must have `landmark.station.create` permission.")
     .add_line(
-        f"A maximum of {MAX_BUS_STOPS_PER_LANDMARK} bus stops are allowed per landmark."
+        f"A maximum of {MAX_STATIONS_PER_LANDMARK} stations are allowed per landmark."
     )
 )
 
 PATCH_DESCRIPTION = (
     Description()
-    .add_head("Updates an existing bus stop.")
+    .add_head("Updates an existing station.")
     .add_line("Empty PATCH requests are allowed and will result in no changes.")
     .add_line(
         "When updating the location, it must remain within the landmark boundary."
     )
-    .add_line("Logged-in executive must have `landmark.bus_stop.update` permission.")
+    .add_line("Logged-in executive must have `landmark.station.update` permission.")
 )
 
 DELETE_DESCRIPTION = (
     Description()
-    .add_head("Deletes an existing bus stop.")
-    .add_line("Returns 204 No Content even if the specified bus stop does not exist.")
-    .add_line("Logged-in executive must have `landmark.bus_stop.delete` permission.")
+    .add_head("Deletes an existing station.")
+    .add_line("Returns 204 No Content even if the specified station does not exist.")
+    .add_line("Logged-in executive must have `landmark.station.delete` permission.")
 )
 
 GET_DESCRIPTION = (
     Description()
-    .add_head("Fetches a list of bus stops.")
+    .add_head("Fetches a list of stations.")
     .add_line(
         "If location is not provided while using order_by=location, the API will fall back to default ordering by id."
     )
@@ -451,15 +451,15 @@ GET_DESCRIPTION = (
 ## Executive
 # ---------------------------------------------------------------------------
 @route_executive.post(
-    URL_BUS_STOP,
-    summary="Create bus stop",
-    tags=["Bus Stop"],
-    response_model=BusStopSchema,
+    URL_STATION,
+    summary="Create station",
+    tags=["Station"],
+    response_model=StationSchema,
     status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(POST_EXCEPTIONS),
     description=(POST_DESCRIPTION.to_string()),
 )
-async def create_bus_stop_for_executive(
+async def create_station_for_executive(
     form_param: CreateForm,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
@@ -467,22 +467,22 @@ async def create_bus_stop_for_executive(
 ):
     try:
         token = authorize_executive(
-            session, access_token, [PermissionPath.CREATE_BUS_STOP]
+            session, access_token, [PermissionPath.CREATE_STATION]
         )
-        return create_bus_stop(session, form_param, token, request_info)
+        return create_station(session, form_param, token, request_info)
     except Exception as e:
         exceptions.handle(e)
 
 
 @route_executive.patch(
-    f"{URL_BUS_STOP}/{{id}}",
-    summary="Update bus stop",
-    tags=["Bus Stop"],
-    response_model=BusStopSchema,
+    f"{URL_STATION}/{{id}}",
+    summary="Update station",
+    tags=["Station"],
+    response_model=StationSchema,
     responses=fuse_exception_responses(PATCH_EXCEPTIONS),
     description=(PATCH_DESCRIPTION.to_string()),
 )
-async def update_bus_stop_for_executive(
+async def update_station_for_executive(
     id: int,
     form_param: UpdateForm,
     access_token=Depends(oauth2_executive),
@@ -491,22 +491,22 @@ async def update_bus_stop_for_executive(
 ):
     try:
         token = authorize_executive(
-            session, access_token, [PermissionPath.UPDATE_BUS_STOP]
+            session, access_token, [PermissionPath.UPDATE_STATION]
         )
-        return update_bus_stop(session, id, form_param, token, request_info)
+        return update_station(session, id, form_param, token, request_info)
     except Exception as e:
         exceptions.handle(e)
 
 
 @route_executive.delete(
-    f"{URL_BUS_STOP}/{{id}}",
-    summary="Delete bus stop",
-    tags=["Bus Stop"],
+    f"{URL_STATION}/{{id}}",
+    summary="Delete station",
+    tags=["Station"],
     status_code=status.HTTP_204_NO_CONTENT,
     responses=fuse_exception_responses(DELETE_EXCEPTIONS),
     description=(DELETE_DESCRIPTION.to_string()),
 )
-async def delete_bus_stop_for_executive(
+async def delete_station_for_executive(
     id: int,
     access_token=Depends(oauth2_executive),
     request_info=Depends(get_request_info),
@@ -514,23 +514,23 @@ async def delete_bus_stop_for_executive(
 ):
     try:
         token = authorize_executive(
-            session, access_token, [PermissionPath.DELETE_BUS_STOP]
+            session, access_token, [PermissionPath.DELETE_STATION]
         )
-        delete_bus_stop(session, id, token, request_info)
+        delete_station(session, id, token, request_info)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         exceptions.handle(e)
 
 
 @route_executive.get(
-    URL_BUS_STOP,
-    summary="Fetch bus stop",
-    tags=["Bus Stop"],
-    response_model=list[BusStopSchema],
+    URL_STATION,
+    summary="Fetch station",
+    tags=["Station"],
+    response_model=list[StationSchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=(GET_DESCRIPTION.to_string()),
 )
-async def fetch_bus_stops_for_executive(
+async def fetch_stations_for_executive(
     query_params: QueryParams = Depends(),
     access_token=Depends(oauth2_executive),
     session: Session = Depends(get_db_session),
@@ -538,8 +538,8 @@ async def fetch_bus_stops_for_executive(
     try:
         verify_token(session, ExecutiveToken, access_token)
         return [
-            bus_stop_to_dict(bus_stop)
-            for bus_stop in search_bus_stops(session, query_params)
+            station_to_dict(station)
+            for station in search_stations(session, query_params)
         ]
     except Exception as e:
         exceptions.handle(e)
@@ -549,14 +549,14 @@ async def fetch_bus_stops_for_executive(
 ## API endpoints [Vendor]
 # ---------------------------------------------------------------------------
 @route_vendor.get(
-    URL_BUS_STOP,
-    summary="Fetch bus stop",
-    tags=["Bus Stop"],
-    response_model=list[BusStopSchema],
+    URL_STATION,
+    summary="Fetch station",
+    tags=["Station"],
+    response_model=list[StationSchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=(GET_DESCRIPTION.to_string()),
 )
-async def fetch_bus_stops_for_vendor(
+async def fetch_stations_for_vendor(
     query_params: QueryParams = Depends(),
     access_token=Depends(bearer_vendor),
     session: Session = Depends(get_db_session),
@@ -564,8 +564,8 @@ async def fetch_bus_stops_for_vendor(
     try:
         verify_token(session, VendorToken, access_token.credentials)
         return [
-            bus_stop_to_dict(bus_stop)
-            for bus_stop in search_bus_stops(session, query_params)
+            station_to_dict(station)
+            for station in search_stations(session, query_params)
         ]
     except Exception as e:
         exceptions.handle(e)
@@ -575,14 +575,14 @@ async def fetch_bus_stops_for_vendor(
 ## API endpoints [Operator]
 # ---------------------------------------------------------------------------
 @route_operator.get(
-    URL_BUS_STOP,
-    summary="Fetch bus stop",
-    tags=["Bus Stop"],
-    response_model=list[BusStopSchema],
+    URL_STATION,
+    summary="Fetch station",
+    tags=["Station"],
+    response_model=list[StationSchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=(GET_DESCRIPTION.to_string()),
 )
-async def fetch_bus_stops_for_operator(
+async def fetch_stations_for_operator(
     query_params: QueryParams = Depends(),
     access_token=Depends(bearer_operator),
     session: Session = Depends(get_db_session),
@@ -590,8 +590,8 @@ async def fetch_bus_stops_for_operator(
     try:
         verify_token(session, OperatorToken, access_token.credentials)
         return [
-            bus_stop_to_dict(bus_stop)
-            for bus_stop in search_bus_stops(session, query_params)
+            station_to_dict(station)
+            for station in search_stations(session, query_params)
         ]
     except Exception as e:
         exceptions.handle(e)
@@ -601,22 +601,22 @@ async def fetch_bus_stops_for_operator(
 ## API endpoints [Public]
 # ---------------------------------------------------------------------------
 @route_public.get(
-    URL_BUS_STOP,
-    summary="Fetch bus stop",
-    tags=["Bus Stop"],
-    response_model=list[BusStopSchema],
+    URL_STATION,
+    summary="Fetch station",
+    tags=["Station"],
+    response_model=list[StationSchema],
     responses=fuse_exception_responses(
         [exceptions.InvalidWKTStringOrType(), exceptions.InvalidSRID4326()]
     ),
     description=(GET_DESCRIPTION.to_string()),
 )
-async def fetch_bus_stops_for_public(
+async def fetch_stations_for_public(
     query_params: QueryParams = Depends(), session: Session = Depends(get_db_session)
 ):
     try:
         return [
-            bus_stop_to_dict(bus_stop)
-            for bus_stop in search_bus_stops(session, query_params)
+            station_to_dict(station)
+            for station in search_stations(session, query_params)
         ]
     except Exception as e:
         exceptions.handle(e)

--- a/app/api/station.py
+++ b/app/api/station.py
@@ -91,7 +91,7 @@ class StationSchema(BaseModel):
 class CreateForm(BaseModel):
     """Form data for creating a new station."""
 
-    name: str = Field(min_length=1, max_length=32, pattern=NAME_PATTERN)
+    name: str = Field(min_length=1, max_length=128, pattern=NAME_PATTERN)
     landmark_id: int = Field()
     location: str = Field(
         description=(
@@ -105,7 +105,7 @@ class UpdateForm(PatchForm):
     """Form data for updating a station."""
 
     name: str | None = Field(
-        min_length=1, max_length=32, pattern=NAME_PATTERN, default=None
+        min_length=1, max_length=128, pattern=NAME_PATTERN, default=None
     )
     location: str | None = Field(
         default=None,

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -83,7 +83,7 @@ MAX_LANDMARK_UPDATE_DISTANCE = 1000  # 1 km
 MIN_LANDMARKS_PER_ROUTE = 2  # Minimum number of landmarks per route
 MAX_LANDMARKS_PER_ROUTE = 100  # # Maximum number of landmarks per route
 MAX_ROUTE_DISTANCE = 10000 * 1000  # Maximum  route length in meters (10000 km)
-MAX_BUS_STOPS_PER_LANDMARK = 20  # Maximum number of bus stops per landmark
+MAX_STATIONS_PER_LANDMARK = 20  # Maximum number of stations per landmark
 
 
 # ---------------------------------------------------------------------------

--- a/app/src/db.py
+++ b/app/src/db.py
@@ -1036,51 +1036,51 @@ class Landmark(ORMbase):
     )
 
 
-class BusStop(ORMbase):
+class Station(ORMbase):
     """
-    Represents a geo-referenced bus stop associated with a specific landmark.
+    Represents a geo-referenced station associated with a specific landmark.
 
-    Bus stops are stored as point-based spatial entities used for mapping,
-    routing, navigation, and proximity-based operations. Each bus stop belongs
+    Stations are stored as point-based spatial entities used for mapping,
+    routing, navigation, and proximity-based operations. Each station belongs
     to a landmark region, enabling localized grouping and spatial queries such as
-    nearest-stop detection, containment checks, or analytics within a landmark area.
+    nearest-station detection, containment checks, or analytics within a landmark area.
 
     Spatial Constraint:
-        - `uq_bus_stop_location_landmark_id` (unique BTree index on ST_AsBinary(location)):
-            Ensures no two bus stops under the same landmark share the exact same
+        - `uq_station_location_landmark_id` (unique BTree index on ST_AsBinary(location)):
+            Ensures no two stations under the same landmark share the exact same
             spatial point. Using ST_AsBinary avoids floating-point comparison issues
             with raw geometry objects.
 
     Columns:
         id (Integer, unique, not null):
-            Primary identifier for the bus stop.
+            Primary identifier for the station.
 
         name (TEXT, not null):
-            Official name of the bus stop.
+            Official name of the station.
             It should be 1-128 characters long.
             May include space ( ), hyphen (-), period (.), and underscore (_).
 
         landmark_id (Integer, not null):
             Foreign key referencing `landmark.id`.
-            Indicates the landmark to which this bus stop belongs.
-            Cascades on delete — all bus stops under a landmark are removed
+            Indicates the landmark to which this station belongs.
+            Cascades on delete — all stations under a landmark are removed
             automatically if the landmark is deleted.
 
         location (Geometry(POINT, SRID 4326), not null):
-            Geo-spatial point representing the exact location of the bus stop.
+            Geo-spatial point representing the exact location of the station.
             Stored as a PostGIS `POINT` geometry using SRID 4326 (WGS 84 longitude/latitude).
-            No two bus stops within the same landmark can share the same location,
-            with uniqueness enforced via the `uq_bus_stop_location_landmark_id`
+            No two stations within the same landmark can share the same location,
+            with uniqueness enforced via the `uq_station_location_landmark_id`
             unique index on `ST_AsBinary(location)` and `landmark_id`.
 
         updated_on (DateTime, nullable, onupdate=func.now()):
-            Timestamp automatically updated whenever the bus stop record is modified.
+            Timestamp automatically updated whenever the station record is modified.
 
         created_on (DateTime, not null, default=func.now()):
-            Timestamp indicating when the bus stop record was created.
+            Timestamp indicating when the station record was created.
     """
 
-    __tablename__ = "bus_stop"
+    __tablename__ = "station"
 
     id: Mapped[int] = orm.mapped_column(BigInteger, primary_key=True)
     name: Mapped[str] = orm.mapped_column(TEXT, nullable=False)
@@ -1102,7 +1102,7 @@ class BusStop(ORMbase):
 
     __table_args__ = (
         Index(
-            "uq_bus_stop_location_landmark_id",
+            "uq_station_location_landmark_id",
             func.ST_AsBinary(location),
             landmark_id,
             unique=True,

--- a/app/src/exceptions.py
+++ b/app/src/exceptions.py
@@ -428,14 +428,14 @@ class InvalidBoundaryArea(APIException):
     headers = {"X-Error": "InvalidBoundaryArea"}
 
 
-class BusStopOutsideLandmark(APIException):
+class StationOutsideLandmark(APIException):
     """
-    Raised when the bus stop location is not within the landmark boundary.
+    Raised when the station location is not within the landmark boundary.
     """
 
     status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
-    detail = "The bus stop location is not within the landmark boundary"
-    headers = {"X-Error": "BusStopOutsideLandmark"}
+    detail = "The station location is not within the landmark boundary"
+    headers = {"X-Error": "StationOutsideLandmark"}
 
 
 class LandmarkDistanceLimitExceeded(APIException):

--- a/app/src/permissions/executive.py
+++ b/app/src/permissions/executive.py
@@ -19,9 +19,9 @@ class PermissionPath(StrEnum):
     UPDATE_LANDMARK = "landmark.update"
     DELETE_LANDMARK = "landmark.delete"
 
-    CREATE_BUS_STOP = "landmark.bus_stop.create"
-    UPDATE_BUS_STOP = "landmark.bus_stop.update"
-    DELETE_BUS_STOP = "landmark.bus_stop.delete"
+    CREATE_STATION = "landmark.station.create"
+    UPDATE_STATION = "landmark.station.update"
+    DELETE_STATION = "landmark.station.delete"
 
     CREATE_FARE = "fare.create"
     UPDATE_FARE = "fare.update"
@@ -120,7 +120,7 @@ class TokenPermission(PermissionBase):
 class LandmarkPermissions(CRUDPermission):
     """Landmark related permissions."""
 
-    bus_stop: CRUDPermission
+    station: CRUDPermission
 
 
 class ExecutivePermissions(CRUDPermission):

--- a/app/src/urls.py
+++ b/app/src/urls.py
@@ -13,7 +13,7 @@ gateway or service base URL when making requests.
 # ---------------------------------------------------------------------------
 URL_HEALTH = "/health"
 URL_LANDMARK = "/landmark"
-URL_BUS_STOP = "/landmark/bus_stop"
+URL_STATION = "/landmark/station"
 
 # ---------------------------------------------------------------------------
 # Executive

--- a/tests/executive/happy_flow.py
+++ b/tests/executive/happy_flow.py
@@ -9,7 +9,7 @@ from app.api.executive_role_map import ExecutiveRoleMapSchema
 from app.api.executive_token import ExecutiveTokenSchema
 from app.api.landmark import LandmarkSchema
 from app.api.landmark_in_route import LandmarkInRouteSchema
-from app.api.bus_stop import BusStopSchema
+from app.api.station import StationSchema
 from app.api.operator_role import OperatorRoleSchema
 from app.api.operator_role_map import OperatorRoleMapSchema
 from app.api.vehicle import VehicleSchema
@@ -32,7 +32,7 @@ from app.src.urls import (
     URL_VEHICLE_PICTURE,
     URL_EXECUTIVE_TOKEN,
     URL_LANDMARK,
-    URL_BUS_STOP,
+    URL_STATION,
     URL_ROUTE,
     URL_BUSINESS,
     URL_VENDOR_PICTURE,
@@ -56,7 +56,7 @@ from tests.inputs import (
     generate_test_image,
     generate_vehicle_payload,
     generate_landmark_payload,
-    generate_bus_stop_payload,
+    generate_station_payload,
     generate_service_assignment_payload,
 )
 from app.api.fare import FareSchema
@@ -251,27 +251,27 @@ def test_landmark_endpoint(landmark_url: str, landmark_data: dict, token_headers
     assert response.status_code == 204
 
 
-def test_bus_stop_endpoint(bus_stop_url: str, bus_stop_data: dict, token_headers: dict):
-    print("Creating bus stop")
-    response = requests.post(bus_stop_url, headers=token_headers, json=bus_stop_data)
+def test_station_endpoint(station_url: str, station_data: dict, token_headers: dict):
+    print("Creating station")
+    response = requests.post(station_url, headers=token_headers, json=station_data)
     assert response.status_code == 201
-    bus_stop = BusStopSchema.model_validate(response.json())
+    station = StationSchema.model_validate(response.json())
 
-    print("Fetching bus stop by id")
-    response = requests.get(f"{bus_stop_url}?id={bus_stop.id}", headers=token_headers)
+    print("Fetching station by id")
+    response = requests.get(f"{station_url}?id={station.id}", headers=token_headers)
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list) and len(data) == 1
 
-    print("Updating bus stop location")
-    update_payload = {"name": f"{bus_stop.name}-updated"}
+    print("Updating station location")
+    update_payload = {"name": f"{station.name}-updated"}
     response = requests.patch(
-        f"{bus_stop_url}/{bus_stop.id}", headers=token_headers, json=update_payload
+        f"{station_url}/{station.id}", headers=token_headers, json=update_payload
     )
     assert response.status_code == 200
 
-    print("Deleting bus stop")
-    response = requests.delete(f"{bus_stop_url}/{bus_stop.id}", headers=token_headers)
+    print("Deleting station")
+    response = requests.delete(f"{station_url}/{station.id}", headers=token_headers)
     assert response.status_code == 204
 
 
@@ -718,7 +718,7 @@ def run_test(target_url):
     TOKEN_URL = f"{target_url}/executive{URL_EXECUTIVE_TOKEN}"
     ROLE_MAP_URL = f"{target_url}/executive{URL_EXECUTIVE_ROLE_MAP}"
     LANDMARK_URL = f"{target_url}/executive{URL_LANDMARK}"
-    BUS_STOP_URL = f"{target_url}/executive{URL_BUS_STOP}"
+    STATION_URL = f"{target_url}/executive{URL_STATION}"
     COMPANY_URL = f"{target_url}/executive{URL_COMPANY}"
     OPERATOR_URL = f"{target_url}/executive{URL_OPERATOR_ACCOUNT}"
     OPERATOR_ROLE_URL = f"{target_url}/executive{URL_OPERATOR_ROLE}"
@@ -914,10 +914,10 @@ def run_test(target_url):
 
     # Test landmark creation, retrieval, updating and deletion
     test_landmark_endpoint(LANDMARK_URL, generate_landmark_payload(), admin_headers)
-    # Test bus stop creation, retrieval, updating and deletion
-    test_bus_stop_endpoint(
-        BUS_STOP_URL,
-        generate_bus_stop_payload(landmark_1.id, landmark_1.boundary),
+    # Test station creation, retrieval, updating and deletion
+    test_station_endpoint(
+        STATION_URL,
+        generate_station_payload(landmark_1.id, landmark_1.boundary),
         admin_headers,
     )
 

--- a/tests/executive/happy_flow.py
+++ b/tests/executive/happy_flow.py
@@ -263,7 +263,7 @@ def test_station_endpoint(station_url: str, station_data: dict, token_headers: d
     data = response.json()
     assert isinstance(data, list) and len(data) == 1
 
-    print("Updating station location")
+    print("Updating station name")
     update_payload = {"name": f"{station.name}-updated"}
     response = requests.patch(
         f"{station_url}/{station.id}", headers=token_headers, json=update_payload

--- a/tests/inputs.py
+++ b/tests/inputs.py
@@ -191,7 +191,7 @@ def generate_landmark_payload():
     }
 
 
-def generate_bus_stop_payload(landmark_id: int, boundary: str):
+def generate_station_payload(landmark_id: int, boundary: str):
     suffix = str(np.random.randint(1000, 9999))
 
     geom = wkt.loads(boundary) if boundary else None
@@ -205,7 +205,7 @@ def generate_bus_stop_payload(landmark_id: int, boundary: str):
 
     location = f"POINT({round(lon,6)} {round(lat,6)})"
     return {
-        "name": f"Bus Stop {suffix}",
+        "name": f"Station {suffix}",
         "landmark_id": landmark_id,
         "location": location,
     }


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
This branch updates the backend from bus stop naming to station naming across API routes, database models, permissions, and tests to keep the implementation aligned with the new domain terminology.

Reason for the change?
- The backend was still using bus stop terminology in several places, while the current domain model and API expectations now use station terminology. This created inconsistencies across the codebase and could confuse consumers of the API.

What changed?
-  Renamed the bus stop API module and related routes to station.
- Updated router registration for executive, vendor, operator, and public endpoints.
- Renamed the underlying database model and table from bus stop to station, including its constraints and related metadata.
- Updated exception messages and permission paths to use station terminology.
- Adjusted the station URL path from /landmark/bus_stop to /landmark/station.
- Updated relevant tests and request payload helpers to reflect the new naming.

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Run the relevant API and happy-flow tests to confirm the station endpoints behave as expected.
- Verify the new station routes are available under the updated URL path.
- Confirm CRUD flows for station-related operations still work correctly.
- Check that permissions and error messages now reference station terminology consistently.

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
N/A

### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
N/A