### PR TITLE
Add UUID support for paper tickets with duplicate prevention

### DIFF
--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -104,7 +104,7 @@ class PaperTicketForm(BaseModel):
     """Form data for a ticket within a paper ticket."""
 
     operator_id: int = Field()
-    sequence_id: str = Field()
+    sequence_id: str = Field(max_length=64)
     created_on: datetime = Field()
     ticket_types: list[TicketTypeSchema] = Field()
     amount: TwoDecimalPlaces = Field()
@@ -362,9 +362,7 @@ def create_paper_ticket(
                 )
                 .returning(PaperTicket)
             )
-
             paper_ticket = session.scalars(stmt).first()
-
             if paper_ticket is not None:
                 paper_tickets.append(paper_ticket)
 

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -333,7 +333,9 @@ def create_paper_ticket(
             try:
                 ticket_payload = {
                     "created_on": ticket.created_on.isoformat(),
-                    "ticket_types": [tt.model_dump(mode="json") for tt in ticket.ticket_types],
+                    "ticket_types": [
+                        tt.model_dump(mode="json") for tt in ticket.ticket_types
+                    ],
                     "pickup_point": ticket.pickup_point,
                     "dropping_point": ticket.dropping_point,
                     "extras": extras,

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -13,6 +13,8 @@ from fastapi import APIRouter, Depends, status, Query
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from sqlalchemy.orm.session import Session
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.api.bearer import bearer_operator, oauth2_executive
 from app.src.db import (
@@ -327,29 +329,47 @@ def create_paper_ticket(
             else:
                 duty = duty_cache[operator_id]
 
-            # Create paper ticket with warnings and uploaded_by info if applicable
-            paper_ticket = PaperTicket(
-                service_id=form_param.service_id,
-                duty_id=duty.id,
-                company_id=token.company_id,
-                ticket={
-                    "sequence_id": ticket.sequence_id,
+            # Create or update the paper ticket with warnings and uploaded_by info if applicable
+            try:
+                ticket_payload = {
                     "created_on": ticket.created_on.isoformat(),
-                    "ticket_types": [
-                        tt.model_dump(mode="json") for tt in ticket.ticket_types
-                    ],
+                    "ticket_types": [tt.model_dump(mode="json") for tt in ticket.ticket_types],
                     "pickup_point": ticket.pickup_point,
                     "dropping_point": ticket.dropping_point,
                     "extras": extras,
-                },
-                amount=ticket.amount,
-            )
-            if warnings:
-                paper_ticket.ticket["warnings"] = [w.value for w in warnings]
-            if token.operator_id != ticket.operator_id:
-                paper_ticket.ticket["uploaded_by"] = token.operator_id
-            session.add(paper_ticket)
-            paper_tickets.append(paper_ticket)
+                    "uuid": ticket.sequence_id,
+                }
+
+                if warnings:
+                    ticket_payload["warnings"] = [w.value for w in warnings]
+                if token.operator_id != ticket.operator_id:
+                    ticket_payload["uploaded_by"] = token.operator_id
+
+                stmt = pg_insert(PaperTicket).values(
+                    service_id=form_param.service_id,
+                    duty_id=duty.id,
+                    company_id=token.company_id,
+                    sequence_id=ticket.sequence_id,
+                    ticket=ticket_payload,
+                    amount=ticket.amount,
+                )
+
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["service_id", "sequence_id"],
+                    set_={
+                        "duty_id": stmt.excluded.duty_id,
+                        "company_id": stmt.excluded.company_id,
+                        "ticket": stmt.excluded.ticket,
+                        "amount": stmt.excluded.amount,
+                    },
+                ).returning(PaperTicket)
+
+                paper_ticket = session.scalars(stmt).one()
+                paper_tickets.append(paper_ticket)
+
+            except SQLAlchemyError as exc:
+                # log the actual DB error here instead of silently swallowing it
+                raise exc
 
         if service.status != ServiceStatus.STARTED:
             service.status = ServiceStatus.STARTED

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -62,7 +62,6 @@ route_operator = APIRouter()
 class MinimalPaperTicketDetailSchema(BaseModel):
     """Schema for the paper ticket batch response."""
 
-    sequence_id: int
     warnings: list[PaperTicketWarning] = Field(default_factory=list)
     uploaded_by: int | None = None
 
@@ -91,6 +90,7 @@ class PaperTicketSchema(BaseModel):
 
     id: int
     service_id: int
+    sequence_id: str
     duty_id: int
     company_id: int
     amount: TwoDecimalPlaces
@@ -105,7 +105,7 @@ class PaperTicketForm(BaseModel):
     """Form data for a ticket within a paper ticket."""
 
     operator_id: int = Field()
-    sequence_id: int = Field()
+    sequence_id: str = Field()
     created_on: datetime = Field()
     ticket_types: list[TicketTypeSchema] = Field()
     amount: TwoDecimalPlaces = Field()
@@ -339,7 +339,6 @@ def create_paper_ticket(
                     "pickup_point": ticket.pickup_point,
                     "dropping_point": ticket.dropping_point,
                     "extras": extras,
-                    "uuid": ticket.sequence_id,
                 }
 
                 if warnings:

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -70,6 +70,7 @@ class MinimalPaperTicketSchema(BaseModel):
 
     id: int
     duty_id: int
+    sequence_id: str
     ticket: MinimalPaperTicketDetailSchema
     created_on: datetime
 
@@ -328,7 +329,7 @@ def create_paper_ticket(
             else:
                 duty = duty_cache[operator_id]
 
-            # Create or update the paper ticket with warnings and uploaded_by info if applicable
+            # Create the paper ticket payload with warnings and uploaded_by info if applicable
             ticket_payload = {
                 "created_on": ticket.created_on.isoformat(),
                 "ticket_types": [
@@ -354,17 +355,19 @@ def create_paper_ticket(
                     ticket=ticket_payload,
                     amount=ticket.amount,
                 )
-                .on_conflict_do_nothing(
+                .on_conflict_do_update(
                     index_elements=[
-                        PaperTicket.service_id.name,
-                        PaperTicket.sequence_id.name,
-                    ]
+                        PaperTicket.service_id,
+                        PaperTicket.sequence_id,
+                    ],
+                    set_={
+                        "sequence_id": PaperTicket.sequence_id,  # no-op update
+                    },
                 )
                 .returning(PaperTicket)
             )
-            paper_ticket = session.scalars(stmt).first()
-            if paper_ticket is not None:
-                paper_tickets.append(paper_ticket)
+            paper_ticket = session.execute(stmt).scalar_one()
+            paper_tickets.append(paper_ticket)
 
         if service.status != ServiceStatus.STARTED:
             service.status = ServiceStatus.STARTED

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -14,7 +14,6 @@ from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 from sqlalchemy.orm.session import Session
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.exc import SQLAlchemyError
 
 from app.api.bearer import bearer_operator, oauth2_executive
 from app.src.db import (
@@ -330,23 +329,24 @@ def create_paper_ticket(
                 duty = duty_cache[operator_id]
 
             # Create or update the paper ticket with warnings and uploaded_by info if applicable
-            try:
-                ticket_payload = {
-                    "created_on": ticket.created_on.isoformat(),
-                    "ticket_types": [
-                        tt.model_dump(mode="json") for tt in ticket.ticket_types
-                    ],
-                    "pickup_point": ticket.pickup_point,
-                    "dropping_point": ticket.dropping_point,
-                    "extras": extras,
-                }
+            ticket_payload = {
+                "created_on": ticket.created_on.isoformat(),
+                "ticket_types": [
+                    tt.model_dump(mode="json") for tt in ticket.ticket_types
+                ],
+                "pickup_point": ticket.pickup_point,
+                "dropping_point": ticket.dropping_point,
+                "extras": extras,
+            }
 
-                if warnings:
-                    ticket_payload["warnings"] = [w.value for w in warnings]
-                if token.operator_id != ticket.operator_id:
-                    ticket_payload["uploaded_by"] = token.operator_id
+            if warnings:
+                ticket_payload["warnings"] = [w.value for w in warnings]
+            if token.operator_id != ticket.operator_id:
+                ticket_payload["uploaded_by"] = token.operator_id
 
-                stmt = pg_insert(PaperTicket).values(
+            stmt = (
+                pg_insert(PaperTicket)
+                .values(
                     service_id=form_param.service_id,
                     duty_id=duty.id,
                     company_id=token.company_id,
@@ -354,23 +354,19 @@ def create_paper_ticket(
                     ticket=ticket_payload,
                     amount=ticket.amount,
                 )
+                .on_conflict_do_nothing(
+                    index_elements=[
+                        PaperTicket.service_id.name,
+                        PaperTicket.sequence_id.name,
+                    ]
+                )
+                .returning(PaperTicket)
+            )
 
-                stmt = stmt.on_conflict_do_update(
-                    index_elements=["service_id", "sequence_id"],
-                    set_={
-                        "duty_id": stmt.excluded.duty_id,
-                        "company_id": stmt.excluded.company_id,
-                        "ticket": stmt.excluded.ticket,
-                        "amount": stmt.excluded.amount,
-                    },
-                ).returning(PaperTicket)
+            paper_ticket = session.scalars(stmt).first()
 
-                paper_ticket = session.scalars(stmt).one()
+            if paper_ticket is not None:
                 paper_tickets.append(paper_ticket)
-
-            except SQLAlchemyError as exc:
-                # log the actual DB error here instead of silently swallowing it
-                raise exc
 
         if service.status != ServiceStatus.STARTED:
             service.status = ServiceStatus.STARTED

--- a/app/src/db.py
+++ b/app/src/db.py
@@ -2811,8 +2811,8 @@ class PaperTicket(ORMbase):
             Cascades on delete — if the service is removed, related tickets are deleted.
 
         sequence_id (String, not null):
-            Unique identifier for the ticket generated at the client side.
-            Must be unique within the context of a service.
+            Client-generated unique identifier for the ticket.
+            Must be unique per service to avoid duplicate ticket entries.
 
         duty_id (Integer, not null):
             Foreign key referencing `duty.id`.
@@ -2825,7 +2825,6 @@ class PaperTicket(ORMbase):
         ticket (JSONB, not null):
             Structured data capturing the ticket details.
             Expected keys and values:
-                - `sequence_id`: Unique identifier for the ticket generated at the client side.
                 - `ticket_types`: List of ticket types.
                 - `pickup_point`: Starting landmark ID of the passenger.
                 - `dropping_point`: Ending landmark ID of the passenger.

--- a/app/src/db.py
+++ b/app/src/db.py
@@ -2839,6 +2839,7 @@ class PaperTicket(ORMbase):
     """
 
     __tablename__ = "paper_ticket"
+    __table_args__ = (UniqueConstraint("service_id", "sequence_id"),)
 
     id: Mapped[int] = orm.mapped_column(BigInteger, primary_key=True)
     service_id: Mapped[int] = orm.mapped_column(
@@ -2847,6 +2848,7 @@ class PaperTicket(ORMbase):
         nullable=False,
         index=True,
     )
+    sequence_id: Mapped[str] = orm.mapped_column(TEXT, nullable=False)
     duty_id: Mapped[int] = orm.mapped_column(
         BigInteger, ForeignKey("duty.id"), nullable=False, index=True
     )

--- a/app/src/db.py
+++ b/app/src/db.py
@@ -2812,7 +2812,7 @@ class PaperTicket(ORMbase):
 
         sequence_id (String, not null):
             Unique identifier for the ticket generated at the client side.
-            Must be unique within the context of a service.    
+            Must be unique within the context of a service.
 
         duty_id (Integer, not null):
             Foreign key referencing `duty.id`.

--- a/app/src/db.py
+++ b/app/src/db.py
@@ -2810,6 +2810,10 @@ class PaperTicket(ORMbase):
             Identifies the service associated with this ticket.
             Cascades on delete — if the service is removed, related tickets are deleted.
 
+        sequence_id (String, not null):
+            Unique identifier for the ticket generated at the client side.
+            Must be unique within the context of a service.    
+
         duty_id (Integer, not null):
             Foreign key referencing `duty.id`.
             Indicates the specific duty under which the ticket was issued.


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
This branch adds UUID-style paper-ticket identifier handling with duplicate prevention by making paper ticket creation idempotent on the service + sequence identifier pair. The result is safer repeated submissions and cleaner data integrity for paper ticket records.

Reason for the change?
- The paper ticket create flow needed to reliably handle repeated submissions for the same logical ticket without generating duplicate database records. The branch introduces a safer idempotent insert path so the same client-generated ticket identifier can be processed more predictably.

What changed? 
- Added support for storing a client-provided ticket identifier in the paper ticket flow, using the existing sequence identifier as the uniqueness anchor.
- Introduced a database uniqueness constraint on the paper ticket record using the service and sequence identifier pair.
- Refactored the insert logic to use an idempotent PostgreSQL upsert pattern so duplicate submissions for the same service + sequence pair are skipped instead of creating duplicate rows.
- Preserved ticket payload details such as created time, ticket types, pickup/drop points, extras, warnings, and uploader metadata in the stored ticket record.
- Improved model-level documentation and schema clarity around the paper ticket structure.

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Run the repository test entrypoint from the project root:
python -m tests.runner
- Validate duplicate-prevention behavior manually:
                  - Create a paper ticket with a given service and sequence identifier.
                  - Submit the same request again.
                  - Confirm the second call does not create a duplicate paper ticket row and returns the expected idempotent behavior.
- Confirm the database uniqueness is enforced for the service + sequence pair.
### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
N/A

### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
