### PR TITLE
Stop exposing collection in public service responses

### DIFF
--- a/app/api/service.py
+++ b/app/api/service.py
@@ -103,7 +103,7 @@ route_public = APIRouter()
 # ---------------------------------------------------------------------------
 ## Output Schema
 # ---------------------------------------------------------------------------
-class ServiceSchema(BaseModel):
+class MaskedServiceSchema(BaseModel):
     """Schema for service response without revealing all details."""
 
     id: int
@@ -158,13 +158,13 @@ class LandmarkInServiceSchema(BaseModel):
     departure_at: datetime
 
 
-class MaskedServiceSchema(ServiceSchema):
+class ServiceSchema(MaskedServiceSchema):
     """Schema for service response with masked details."""
 
     collection: Decimal | None
 
 
-class PublicServiceSchema(ServiceSchema):
+class MaskedServiceDetailSchema(MaskedServiceSchema):
     """Schema for service response with masked details."""
 
     fare: FareInServiceSchema
@@ -172,7 +172,7 @@ class PublicServiceSchema(ServiceSchema):
     route: list[LandmarkInServiceSchema]
 
 
-class PrivateServiceSchema(PublicServiceSchema):
+class ServiceDetailSchema(MaskedServiceDetailSchema):
     """Schema for service response with detailed information."""
 
     public_key: str
@@ -1356,7 +1356,7 @@ GET_DETAIL_DESCRIPTION = Description().add_head("Fetch service details by ID.")
     URL_SERVICE,
     summary="Create service",
     tags=["Service"],
-    response_model=ServiceSchema,
+    response_model=MaskedServiceSchema,
     status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(POST_EXCEPTIONS),
     description=POST_DESCRIPTION.copy()
@@ -1394,7 +1394,7 @@ async def create_service_for_executive(
     f"{URL_SERVICE}/{{id}}",
     summary="Update service",
     tags=["Service"],
-    response_model=ServiceSchema,
+    response_model=MaskedServiceSchema,
     responses=fuse_exception_responses(PATCH_EXCEPTIONS),
     description=PATCH_DESCRIPTION.copy()
     .add_line("Logged-in executive must have `company.service.update` permission.")
@@ -1426,7 +1426,7 @@ async def update_service_for_executive(
     URL_SERVICE,
     summary="Fetch service",
     tags=["Service"],
-    response_model=list[MaskedServiceSchema],
+    response_model=list[ServiceSchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=GET_DESCRIPTION.to_string(),
 )
@@ -1449,7 +1449,7 @@ async def fetch_services_for_executive(
     f"{URL_SERVICE}/{{id}}",
     summary="Fetch service details",
     tags=["Service"],
-    response_model=PublicServiceSchema,
+    response_model=MaskedServiceDetailSchema,
     responses=fuse_exception_responses(
         [*GET_DETAIL_EXCEPTIONS, exceptions.InvalidToken()]
     ),
@@ -1500,7 +1500,7 @@ async def delete_service_for_executive(
     URL_SERVICE,
     summary="Create service",
     tags=["Service"],
-    response_model=ServiceSchema,
+    response_model=MaskedServiceSchema,
     status_code=status.HTTP_201_CREATED,
     responses=fuse_exception_responses(POST_EXCEPTIONS),
     description=POST_DESCRIPTION.copy()
@@ -1537,7 +1537,7 @@ async def create_service_for_operator(
     f"{URL_SERVICE}/{{id}}",
     summary="Update service",
     tags=["Service"],
-    response_model=ServiceSchema,
+    response_model=MaskedServiceSchema,
     status_code=status.HTTP_200_OK,
     responses=fuse_exception_responses(PATCH_EXCEPTIONS),
     description=PATCH_DESCRIPTION.copy()
@@ -1577,7 +1577,7 @@ async def update_service_for_operator(
     URL_SERVICE,
     summary="Fetch service",
     tags=["Service"],
-    response_model=list[MaskedServiceSchema],
+    response_model=list[ServiceSchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=GET_DESCRIPTION.to_string(),
 )
@@ -1600,7 +1600,7 @@ async def fetch_services_for_operator(
     f"{URL_SERVICE}/{{id}}",
     summary="Fetch service details",
     tags=["Service"],
-    response_model=PrivateServiceSchema,
+    response_model=ServiceDetailSchema,
     responses=fuse_exception_responses(
         [*GET_DETAIL_EXCEPTIONS, exceptions.InvalidToken()]
     ),
@@ -1663,7 +1663,7 @@ async def delete_service_for_operator(
     URL_SERVICE,
     summary="Fetch service",
     tags=["Service"],
-    response_model=list[ServiceSchema],
+    response_model=list[MaskedServiceSchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=GET_DESCRIPTION.to_string(),
 )
@@ -1686,7 +1686,7 @@ async def fetch_services_for_vendor(
     f"{URL_SERVICE}/{{id}}",
     summary="Fetch service details",
     tags=["Service"],
-    response_model=PublicServiceSchema,
+    response_model=MaskedServiceDetailSchema,
     responses=fuse_exception_responses(
         [*GET_DETAIL_EXCEPTIONS, exceptions.InvalidToken()]
     ),
@@ -1711,7 +1711,7 @@ async def fetch_service_details_for_vendor(
     URL_SERVICE,
     summary="Fetch service",
     tags=["Service"],
-    response_model=list[ServiceSchema],
+    response_model=list[MaskedServiceSchema],
     description=(
         GET_DESCRIPTION.copy()
         .add_line("Public users can fetch services without authentication.")
@@ -1733,7 +1733,7 @@ async def fetch_services_for_public(
     f"{URL_SERVICE}/{{id}}",
     summary="Fetch service details",
     tags=["Service"],
-    response_model=PublicServiceSchema,
+    response_model=MaskedServiceDetailSchema,
     responses=fuse_exception_responses(GET_DETAIL_EXCEPTIONS),
     description=GET_DETAIL_DESCRIPTION.to_string(),
 )

--- a/app/api/service.py
+++ b/app/api/service.py
@@ -158,6 +158,12 @@ class LandmarkInServiceSchema(BaseModel):
     departure_at: datetime
 
 
+class MaskedServiceSchema(ServiceSchema):
+    """Schema for service response with masked details."""
+
+    collection: Decimal | None
+
+
 class PublicServiceSchema(ServiceSchema):
     """Schema for service response with masked details."""
 
@@ -170,7 +176,6 @@ class PrivateServiceSchema(PublicServiceSchema):
     """Schema for service response with detailed information."""
 
     public_key: str
-    collection: Decimal | None
 
 
 # ---------------------------------------------------------------------------
@@ -1421,7 +1426,7 @@ async def update_service_for_executive(
     URL_SERVICE,
     summary="Fetch service",
     tags=["Service"],
-    response_model=list[ServiceSchema],
+    response_model=list[MaskedServiceSchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=GET_DESCRIPTION.to_string(),
 )
@@ -1572,7 +1577,7 @@ async def update_service_for_operator(
     URL_SERVICE,
     summary="Fetch service",
     tags=["Service"],
-    response_model=list[ServiceSchema],
+    response_model=list[MaskedServiceSchema],
     responses=fuse_exception_responses(GET_EXCEPTIONS),
     description=GET_DESCRIPTION.to_string(),
 )

--- a/app/api/service.py
+++ b/app/api/service.py
@@ -121,7 +121,6 @@ class ServiceSchema(BaseModel):
     remark: str | None
     starting_at: datetime
     ending_at: datetime
-    collection: Decimal | None
     updated_on: datetime | None = None
     created_on: datetime
 
@@ -171,6 +170,7 @@ class PrivateServiceSchema(PublicServiceSchema):
     """Schema for service response with detailed information."""
 
     public_key: str
+    collection: Decimal | None
 
 
 # ---------------------------------------------------------------------------

--- a/app/api/service.py
+++ b/app/api/service.py
@@ -159,7 +159,7 @@ class LandmarkInServiceSchema(BaseModel):
 
 
 class ServiceSchema(MaskedServiceSchema):
-    """Schema for service response with masked details."""
+    """Schema for service response with additional details."""
 
     collection: Decimal | None
 

--- a/tests/executive/happy_flow.py
+++ b/tests/executive/happy_flow.py
@@ -38,7 +38,7 @@ from app.src.urls import (
     URL_VENDOR_PICTURE,
     URL_VENDOR_ACCOUNT,
 )
-from app.api.service import ServiceSchema
+from app.api.service import MaskedServiceSchema
 from app.api.service_assignment import ServiceAssignmentSchema
 from tests.inputs import (
     generate_company_payload,
@@ -562,7 +562,7 @@ def test_service_endpoint(service_url: str, service_data: dict, token_headers: d
     print("Creating service")
     response = requests.post(service_url, headers=token_headers, json=service_data)
     assert response.status_code == 201
-    svc = ServiceSchema.model_validate(response.json())
+    svc = MaskedServiceSchema.model_validate(response.json())
 
     print("Fetching service list")
     response = requests.get(f"{service_url}?id={svc.id}", headers=token_headers)
@@ -590,7 +590,7 @@ def test_service_endpoint(service_url: str, service_data: dict, token_headers: d
 
 def test_service_assignment(
     service_assignment_url: str,
-    service: ServiceSchema,
+    service: MaskedServiceSchema,
     operator_1: OperatorSchema,
     operator_2: OperatorSchema,
     company: CompanySchema,
@@ -875,7 +875,7 @@ def run_test(target_url):
         json=generate_service_payload(route.id, fare.id, vehicle.id, company.id),
     )
     assert response.status_code == 201
-    service = ServiceSchema.model_validate(response.json())
+    service = MaskedServiceSchema.model_validate(response.json())
 
     # Business
     print("Creating business")


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
Narrows the public API surface by removing internal collection data from public service responses and cleaning up the schema structure in service.py for better separation between public and internal behavior.

Reason for the change?
- Remove the internal collection field from the public service response model and clean up the associated public-facing schema/import structure to keep the API surface minimal and appropriate for public consumers.

What changed? 
- Updated the service response schema in service.py so the public endpoint no longer exposes collection.
- Kept private/internal service data isolated from the public API contract.
- Cleaned up the related schema/import usage to avoid unnecessary public exposure.

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Open the public service endpoints in  service.py
- Confirm the public response models no longer include collection.
- Hit the public service list/details endpoints and verify the payload does not return the internal collection field.
- Run the relevant API or schema validation tests to confirm there are no regressions.

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
N/A

### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
