### PR TITLE
Update Swagger documentation to include guidance on unique sequence_id for paper tickets

### DIFF
--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -477,6 +477,9 @@ POST_DESCRIPTION = (
         "If no warnings are generated, `warnings` will be empty. `uploaded_by` is only populated when an operator mismatch occurs."
     )
     .add_line("A maximum of 50 tickets can be created in a single batch upload.")
+    .add_line(
+        "Each ticket must include a unique `sequence_id` (max 64 characters) to identify it within the batch."
+    )
     .add_line("Duplicate sequence IDs within the same batch are not allowed.")
 )
 


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
Updates the Swagger documentation for the paper ticket POST endpoint to clearly explain the expected behavior of the sequence_id field, including its uniqueness and maximum length requirements.

Reason for the change?
- The existing Swagger docs did not clearly communicate that each ticket in a paper ticket batch must include a unique sequence_id and that the value must be no more than 64 characters. This made the API contract less clear for consumers.

What changed?
-  Added a field-level description for sequence_id in the paper ticket request schema.
- Updated the POST endpoint description to explicitly state that:
                - each ticket must include a unique sequence_id
                - sequence_id must be max 64 characters
                - sequence_id is used to identify the ticket within the batch

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Open the Swagger UI for the paper ticket POST endpoint.
- Confirm that the request schema now shows a description for sequence_id.
- Confirm that the endpoint description includes the note about unique sequence_id and the 64-character limit.
- Verify that the API behavior remains unchanged and the documentation update is reflected correctly.

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [ ] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
N/A

### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
