### PR TITLE
Add service level limit for paper ticket creation

### DIFF
--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -31,6 +31,7 @@ from app.src.db import (
 from app.src.enums import DutyStatus, ServiceStatus, OrderIn
 from app.src.urls import URL_PAPER_TICKET
 from app.src.description import Description
+from app.src.constants import MAX_PAPER_TICKETS_PER_SERVICE
 from app.src.validators import (
     verify_token,
     validate_id,
@@ -233,6 +234,15 @@ def create_paper_ticket(
         assert (
             current_landmark is not None
         ), "Current landmark in service should exist for the service location"
+
+        paper_ticket_count = (
+            session.query(PaperTicket)
+            .filter(PaperTicket.service_id == form_param.service_id)
+            .count()
+        )
+
+        if paper_ticket_count >= MAX_PAPER_TICKETS_PER_SERVICE:
+            raise exceptions.LimitExceeded(PaperTicket)
 
         for ticket in form_param.tickets:
             pickup_point = landmarks_in_service_map.get(ticket.pickup_point)
@@ -439,6 +449,7 @@ POST_EXCEPTIONS = [
     exceptions.JSMemoryLimitExceeded(),
     exceptions.JSTimeLimitExceeded(),
     exceptions.LockAcquireTimeout(),
+    exceptions.LimitExceeded(PaperTicket),
 ]
 
 GET_EXCEPTIONS = [
@@ -478,6 +489,9 @@ POST_DESCRIPTION = (
     )
     .add_line("A maximum of 50 tickets can be created in a single batch upload.")
     .add_line("Duplicate sequence IDs within the same batch are not allowed.")
+    .add_line(
+        f"A maximum of {MAX_PAPER_TICKETS_PER_SERVICE} tickets can be created for each service."
+    )
 )
 
 GET_DESCRIPTION = Description().add_head("Fetches a list of paper tickets.")

--- a/app/api/paper_ticket.py
+++ b/app/api/paper_ticket.py
@@ -240,7 +240,6 @@ def create_paper_ticket(
             .filter(PaperTicket.service_id == form_param.service_id)
             .count()
         )
-
         if paper_ticket_count >= MAX_PAPER_TICKETS_PER_SERVICE:
             raise exceptions.LimitExceeded(PaperTicket)
 

--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -92,6 +92,9 @@ MAX_STATIONS_PER_LANDMARK = 20  # Maximum number of stations per landmark
 SERVICE_START_LEAD_TIME_MINUTES = 60  # Minimum buffer before a service starts
 SERVICE_CREATION_LEAD_TIME_DAYS = 1  # Minimum buffer before a service can be created
 MAX_DUTIES_PER_SERVICE = 50  # Maximum number of duties allowed per service
+MAX_PAPER_TICKETS_PER_SERVICE = (
+    65536  # Maximum number of paper tickets allowed per service
+)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### **Summary of Changes**
<!-- Clearly describe what this PR changes and why. Link related issues if applicable. -->
This change adds a hard per-service limit for paper ticket creation, preventing unbounded ticket accumulation on one service while preserving the existing per-batch upload validation. The new cap is defined as 65536 tickets per service and is enforced during creation by counting existing tickets for the service before accepting more.

Reason for the change?

- introduces a per-service ceiling for paper ticket creation so a single service cannot grow without a defined upper bound. The existing batch behavior only limited a single upload to 50 tickets, but there was no overall cap enforced at the service level. 

What changed?

-  Added a new service-wide constant in constants.py
                - MAX_PAPER_TICKETS_PER_SERVICE - 65536
- Added a guard in the paper ticket create flow in paper_ticket.py
                - counts existing paper tickets for the target service_id
- raises LimitExceeded(PaperTicket) when the count reaches the configured service-level cap
- Updated the API exception list in paper_ticket.py so the new limit is surfaced in the endpoint's error contract.
- Updated the endpoint description in
               -paper_ticket.py to document the new service-wide ticket cap.

### **How to Test / Verify**
<!-- Provide steps for reviewers to manually test the changes or mention tests added. -->
- Create a paper ticket batch via the existing paper ticket POST endpoint.
- Repeatedly create additional batches for the same service_id
- Verify that once the total count for that service reaches 65536, the next request is rejected with a LimitExceeded error
- Confirm the request body still accepts the normal batch format and that the new limit is enforced only at the service level, not inside a single upload batch.

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.
- [x] I have reviewed my own code for potential issues.
- [x] I have applied code formatting/linting.
- [x] I have added or updated tests as needed.
- [x] I have added or updated documentation/comments where necessary.


### **Additional Notes (Optional)**
<!-- Add screenshots, performance considerations, or anything else relevant. -->
N/A

### **Reviewer Notes**
<!-- Leave this section for reviewers to add their notes or questions. -->
